### PR TITLE
kubernetes version fixed to 1.21.2

### DIFF
--- a/src/core/variables.tf
+++ b/src/core/variables.tf
@@ -91,7 +91,7 @@ variable "aks_max_pods" {
 
 variable "kubernetes_version" {
   type    = string
-  default = null
+  default = "1.21.2"
 }
 
 variable "aks_sku_tier" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
kubernetes version fixed to 1.21.2

<!--- Describe your changes in detail -->

### Motivation and context
we are using some monitor metrics not available before 1.21 version, while Azure as default provision version 1.20
we are setting the actually last version
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
