### PR TITLE
no SERVER_PORT env for hub-spid-login

### DIFF
--- a/src/k8s/selc_configmaps.tf
+++ b/src/k8s/selc_configmaps.tf
@@ -7,8 +7,6 @@ resource "kubernetes_config_map" "hub-spid-login-ms" {
   data = merge({
     JAVA_TOOL_OPTIONS = ""
 
-    SERVER_PORT = 8080
-
     # SPID
     ORG_URL          = "https://pagopa.gov.it"
     ACS_BASE_URL     = format("%s/spid/v1", var.api_gateway_url)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

removed SERVER_PORT from hub-spid-login config map

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
