### PR TITLE
[SELC-284] Remove unused data from spid info

### DIFF
--- a/src/k8s/selc_configmaps.tf
+++ b/src/k8s/selc_configmaps.tf
@@ -40,7 +40,7 @@ resource "kubernetes_config_map" "hub-spid-login-ms" {
     ENDPOINT_METADATA = "/metadata"
     ENDPOINT_LOGOUT   = "/logout"
 
-    SPID_ATTRIBUTES    = "address,email,name,familyName,fiscalNumber,mobilePhone"
+    SPID_ATTRIBUTES    = "name,familyName,fiscalNumber"
     SPID_VALIDATOR_URL = "https://validator.spid.gov.it"
 
     REQUIRED_ATTRIBUTES_SERVICE_NAME = "Selfcare Portal"


### PR DESCRIPTION

### List of changes
Change the variable SPID_ATTRIBUTES used by hub-spid-login-ms to minimize spid assertion requested to IDP.

### Motivation and context

Request only used information about user to IDP through spid

### Type of changes

- [ ] Add new resources
- [x ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
