### PR TITLE
Selc 458 fix spid testenv trigger

### DIFF
--- a/src/core/env/dev/spid_testenv_conf/config.yaml
+++ b/src/core/env/dev/spid_testenv_conf/config.yaml
@@ -3,7 +3,7 @@
 #########################
 
 # The base URL where spid-testenv2 is reachable at.
-base_url: "https://selc-u-spid-testenv.westeurope.azurecontainer.io"
+base_url: "https://selc-d-spid-testenv.westeurope.azurecontainer.io"
 
 # Key and certificate used to sign SAML messages.
 key_file: "./conf/idp.key"

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -1,4 +1,5 @@
 # general
+env       = "dev"
 env_short = "d"
 
 tags = {

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -1,4 +1,5 @@
 # general
+env       = "prod"
 env_short = "p"
 
 tags = {

--- a/src/core/env/uat/spid_testenv_conf/config.yaml
+++ b/src/core/env/uat/spid_testenv_conf/config.yaml
@@ -1,0 +1,57 @@
+---
+# Identity Provider (IdP)
+#########################
+
+# The base URL where spid-testenv2 is reachable at.
+base_url: "https://selc-u-spid-testenv.westeurope.azurecontainer.io"
+
+# Key and certificate used to sign SAML messages.
+key_file: "./conf/idp.key"
+cert_file: "./conf/idp.crt"
+
+# Service Providers
+###################
+
+# You can configure multiple Service Provider by specifying their XML metadata,
+# using different sources.
+metadata:
+  remote:
+    - "https://api.uat.selfcare.pagopa.it/spid/v1/metadata"
+
+
+# Application configuration
+###########################
+
+# Whether to enable debug mode. When enabled, the log will be more verbose.
+debug: true
+
+# Bind the webserver to the specified IP address (use 0.0.0.0 for all interfaces).
+host: "0.0.0.0"
+# Port the webserver listens on.
+port: 8088
+
+# Whether to enable HTTPS.
+https: false
+
+# The TLS key and certificate used for HTTPS, required if HTTPS is enabled.
+# https_key_file: "path/to/key"
+# https_cert_file: "path/to/cert"
+
+# File holding the identities of test users.
+# It will be automatically created if it doesn't exist.
+users_file: "conf/users.json"
+
+# PostgreSQL database holding the identities of test users.
+# If specified, it will override the "user_file" parameter.
+# The required tables will be automatically created if they don't exist.
+# users_db: 'postgresql+psycopg2://postgres:@localhost:5432/exampledb'
+
+# If enabled, allows to add new users from the UI.
+can_add_user: true
+
+# Whether to enable the UI to handle the data in the database.
+database_admin_interface: true
+
+# If enabled, allows the user to manipulate the response from the Identity Provider.
+# Useful to simulate errors in the response.
+show_response_options: true

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -1,4 +1,5 @@
 # general
+env       = "uat"
 env_short = "u"
 
 tags = {

--- a/src/core/spid-testenv.tf
+++ b/src/core/spid-testenv.tf
@@ -9,5 +9,7 @@ module "spid-test-env" {
 
   hub_spid_login_metadata_url = format("https://api.%s.%s/spid/v1/metadata", var.dns_zone_prefix, var.external_domain)
 
+  spid_testenv_local_config_dir = format("./env/%s/spid_testenv_conf", var.env)
+
   tags = var.tags
 }

--- a/src/core/variables.tf
+++ b/src/core/variables.tf
@@ -11,11 +11,16 @@ variable "prefix" {
   }
 }
 
+variable "env" {
+  type = string
+  description = "env directory name"
+}
+
 variable "env_short" {
   type = string
   validation {
     condition = (
-      length(var.env_short) <= 1
+    length(var.env_short) <= 1
     )
     error_message = "Max length is 1 chars."
   }

--- a/src/core/variables.tf
+++ b/src/core/variables.tf
@@ -12,7 +12,7 @@ variable "prefix" {
 }
 
 variable "env" {
-  type = string
+  type        = string
   description = "env directory name"
 }
 
@@ -20,7 +20,7 @@ variable "env_short" {
   type = string
   validation {
     condition = (
-    length(var.env_short) <= 1
+      length(var.env_short) <= 1
     )
     error_message = "Max length is 1 chars."
   }

--- a/src/modules/spid_testenv/spid-testenv.tf
+++ b/src/modules/spid_testenv/spid-testenv.tf
@@ -129,7 +129,7 @@ resource "azurerm_container_group" "spid_testenv" {
 resource "local_file" "spid_testenv_config" {
   count    = var.enable_spid_test ? 1 : 0
   filename = format("%s/config.yaml", var.spid_testenv_local_config_dir)
-  content  = templatefile(
+  content = templatefile(
     "${path.module}/spid_testenv_conf/config.yaml.tpl",
     {
       base_url                      = format("https://%s", trim(azurerm_container_group.spid_testenv[0].fqdn, "."))

--- a/src/modules/spid_testenv/spid-testenv.tf
+++ b/src/modules/spid_testenv/spid-testenv.tf
@@ -128,8 +128,8 @@ resource "azurerm_container_group" "spid_testenv" {
 
 resource "local_file" "spid_testenv_config" {
   count    = var.enable_spid_test ? 1 : 0
-  filename = "./spid_testenv_conf/config.yaml"
-  content = templatefile(
+  filename = format("%s/config.yaml", var.spid_testenv_local_config_dir)
+  content  = templatefile(
     "${path.module}/spid_testenv_conf/config.yaml.tpl",
     {
       base_url                      = format("https://%s", trim(azurerm_container_group.spid_testenv[0].fqdn, "."))
@@ -149,7 +149,7 @@ resource "null_resource" "upload_config_spid_testenv" {
                 --account-name ${azurerm_storage_account.spid_testenv_storage_account[0].name} \
                 --account-key ${azurerm_storage_account.spid_testenv_storage_account[0].primary_access_key} \
                 --share-name ${azurerm_storage_share.spid_testenv_storage_share[0].name} \
-                --source "./spid_testenv_conf/config.yaml" \
+                --source "${var.spid_testenv_local_config_dir}/config.yaml" \
                 --path "config.yaml" && \
               az container restart \
                 --name ${azurerm_container_group.spid_testenv[0].name} \

--- a/src/modules/spid_testenv/variables.tf
+++ b/src/modules/spid_testenv/variables.tf
@@ -16,6 +16,10 @@ variable "enable_spid_test" {
   type = bool
 }
 
+variable "spid_testenv_local_config_dir" {
+  type = string
+}
+
 variable "hub_spid_login_metadata_url" {
   type = string
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

SELC-458 fixed trigger on spidTestEnv to ignore environment specific configuration

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
