### PR TITLE
PIN-1456: Interop UAT domain delegation

### DIFF
--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -84,3 +84,10 @@ postgres_alerts_enabled = false
 enable_spid_test = true
 
 robots_indexed_paths = []
+
+dns_ns_interop_selfcare = [
+  "ns-170.awsdns-21.com",
+  "ns-1277.awsdns-31.org",
+  "ns-1563.awsdns-03.co.uk",
+  "ns-671.awsdns-19.net",
+]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Added details for Interop domain delegation for UAT environment

### Motivation and context

Interop project needs to configure its DNS as `interop.uat.selfcare.pagopa.it`

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

A PR for production environment will follow

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
