### PR TITLE
Using test pec as destination if not prod

### DIFF
--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -101,7 +101,7 @@ resource "kubernetes_secret" "mail" {
     },
     var.env_short != "p"
     ? {
-      DESTINATION_MAILS = module.key_vault_secrets_query.values["smtp-usr"].value
+      DESTINATION_MAILS = "pectest@pec.pagopa.it"
     }
     : {}
   )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Using selfcare test's pec as destination when not PROD

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
