### PR TITLE
renamed queryparam allowedStatus on getUserGroups to status

### DIFF
--- a/src/core/api/ms_user_group/v1/open-api.yml.tpl
+++ b/src/core/api/ms_user_group/v1/open-api.yml.tpl
@@ -71,7 +71,7 @@ paths:
         schema:
           type: string
           format: uuid
-      - name: allowedStatus
+      - name: status
         in: query
         description: If filter on status is present, it must be used with at least
           one of the other filters


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Changed queryParam name in getUserGroups API from allowedStatus to status

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
