### PR TITLE
feat: Cosmosdb ignore autoscale settings

### DIFF
--- a/src/core/mongodb.tf
+++ b/src/core/mongodb.tf
@@ -122,7 +122,7 @@ resource "azurerm_key_vault_secret" "cosmosdb_account_mongodb_connection_strings
 
 # Collections
 module "mongdb_collection_products" {
-  source = "git::https://github.com/pagopa/azurerm.git//cosmosdb_mongodb_collection?ref=v2.3.0"
+  source = "git::https://github.com/pagopa/azurerm.git//cosmosdb_mongodb_collection?ref=v3.3.0"
 
   name                = "products"
   resource_group_name = azurerm_resource_group.mongodb_rg.name
@@ -144,7 +144,7 @@ module "mongdb_collection_products" {
 }
 
 module "mongdb_collection_user-groups" {
-  source = "git::https://github.com/pagopa/azurerm.git//cosmosdb_mongodb_collection?ref=v2.3.0"
+  source = "git::https://github.com/pagopa/azurerm.git//cosmosdb_mongodb_collection?ref=v3.3.0"
 
   name                = "userGroups"
   resource_group_name = azurerm_resource_group.mongodb_rg.name

--- a/src/core/mongodb.tf
+++ b/src/core/mongodb.tf
@@ -68,6 +68,12 @@ resource "azurerm_cosmosdb_mongo_database" "selc_product" {
       max_throughput = var.cosmosdb_mongodb_max_throughput
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      autoscale_settings
+    ]
+  }
 }
 
 resource "azurerm_management_lock" "mongodb_selc_product" {
@@ -89,6 +95,12 @@ resource "azurerm_cosmosdb_mongo_database" "selc_user_group" {
     content {
       max_throughput = var.cosmosdb_mongodb_max_throughput
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      autoscale_settings
+    ]
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- mongodb ignore autoscale settings

### Motivation and context

Cosmosdb now are manged manually to avoid problems with terraform an decrease costs

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
