### PR TITLE
fix cidr_subnet_private_endpoints

### DIFF
--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -1078,6 +1078,11 @@ variable "docker_registry" {
       regional_endpoint_enabled = bool
       zone_redundancy_enabled   = bool
     })
+    network_rule_set = object({
+      default_action  = string
+      ip_rule         = list(any)
+      virtual_network = list(any)
+    })
   })
 }
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -97,6 +97,7 @@
 | [azurerm_api_management_named_value.apim_named_value_backend_access_token](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_named_value) | resource |
 | [azurerm_application_insights.application_insights](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/application_insights) | resource |
 | [azurerm_container_group.load_tests_db](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/container_group) | resource |
+| [azurerm_cosmosdb_mongo_database.selc_ms_core](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/cosmosdb_mongo_database) | resource |
 | [azurerm_cosmosdb_mongo_database.selc_product](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/cosmosdb_mongo_database) | resource |
 | [azurerm_cosmosdb_mongo_database.selc_user_group](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/cosmosdb_mongo_database) | resource |
 | [azurerm_dashboard.monitoring-dashboard](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/dashboard) | resource |
@@ -299,7 +300,7 @@
 | <a name="input_dns_default_ttl_sec"></a> [dns\_default\_ttl\_sec](#input\_dns\_default\_ttl\_sec) | value | `number` | `3600` | no |
 | <a name="input_dns_ns_interop_selfcare"></a> [dns\_ns\_interop\_selfcare](#input\_dns\_ns\_interop\_selfcare) | value | `list(string)` | `null` | no |
 | <a name="input_dns_zone_prefix"></a> [dns\_zone\_prefix](#input\_dns\_zone\_prefix) | The dns subdomain. | `string` | `"selfcare"` | no |
-| <a name="input_docker_registry"></a> [docker\_registry](#input\_docker\_registry) | ACR docker registry configuration | <pre>object({<br>    sku                     = string<br>    zone_redundancy_enabled = bool<br>    geo_replication = object({<br>      enabled                   = bool<br>      regional_endpoint_enabled = bool<br>      zone_redundancy_enabled   = bool<br>    })<br>  })</pre> | n/a | yes |
+| <a name="input_docker_registry"></a> [docker\_registry](#input\_docker\_registry) | ACR docker registry configuration | <pre>object({<br>    sku                     = string<br>    zone_redundancy_enabled = bool<br>    geo_replication = object({<br>      enabled                   = bool<br>      regional_endpoint_enabled = bool<br>      zone_redundancy_enabled   = bool<br>    })<br>    network_rule_set = object({<br>      default_action  = string<br>      ip_rule         = list(any)<br>      virtual_network = list(any)<br>    })<br>  })</pre> | n/a | yes |
 | <a name="input_enable_app_projects_pipeline"></a> [enable\_app\_projects\_pipeline](#input\_enable\_app\_projects\_pipeline) | If true create the key vault policy to allow used by azure devops app projects pipelines. | `bool` | `false` | no |
 | <a name="input_enable_azdoa"></a> [enable\_azdoa](#input\_enable\_azdoa) | Enable Azure DevOps agent. | `bool` | n/a | yes |
 | <a name="input_enable_iac_pipeline"></a> [enable\_iac\_pipeline](#input\_enable\_iac\_pipeline) | If true create the key vault policy to allow used by azure devops iac pipelines. | `bool` | `false` | no |

--- a/src/core/docker_registry_common.tf
+++ b/src/core/docker_registry_common.tf
@@ -16,6 +16,12 @@ module "acr_common" {
   zone_redundancy_enabled       = var.docker_registry.zone_redundancy_enabled
   public_network_access_enabled = true
 
+  network_rule_set = [{
+    default_action  = var.docker_registry.network_rule_set.default_action
+    ip_rule         = var.docker_registry.network_rule_set.ip_rule
+    virtual_network = var.docker_registry.network_rule_set.virtual_network
+  }]
+
   private_endpoint = {
     enabled              = false
     private_dns_zone_ids = [""]

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -89,6 +89,11 @@ docker_registry = {
     regional_endpoint_enabled = false
     zone_redundancy_enabled   = false
   }
+  network_rule_set = {
+    default_action  = "Deny"
+    ip_rule         = []
+    virtual_network = []
+  }
 }
 
 # CosmosDb MongoDb

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -96,6 +96,11 @@ docker_registry = {
     regional_endpoint_enabled = true
     zone_redundancy_enabled   = true
   }
+  network_rule_set = {
+    default_action  = "Allow"
+    ip_rule         = []
+    virtual_network = []
+  }
 }
 
 # CosmosDb MongoDb

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -31,10 +31,9 @@ cidr_subnet_apim                  = ["10.1.136.0/24"]
 cidr_subnet_contract_storage      = ["10.1.137.0/24"]
 cidr_subnet_eventhub              = ["10.1.138.0/24"]
 cidr_subnet_logs_storage          = ["10.1.139.0/24"]
-cidr_subnet_aks_platform          = ["10.1.139.0/24"]
-cidr_subnet_pnpg_cosmosdb_mongodb = ["10.1.140.0/24"] #this is a place holder for pnpg mongo
-cidr_subnet_private_endpoints     = ["10.1.141.0/24"]
-cidr_subnet_load_tests            = ["10.1.142.0/29"]
+cidr_subnet_private_endpoints     = ["10.1.140.0/24"]
+cidr_subnet_pnpg_cosmosdb_mongodb = ["10.1.141.0/24"] #this is a place holder for pnpg mongo
+cidr_subnet_load_tests            = ["10.1.142.0/24"]
 
 #
 # AKS Platform
@@ -70,8 +69,8 @@ redis_capacity = 0
 aks_alerts_enabled                  = false
 aks_kubernetes_version              = "1.23.12"
 aks_system_node_pool_os_disk_type   = "Managed"
-aks_system_node_pool_node_count_min = 2
-aks_system_node_pool_node_count_max = 3
+aks_system_node_pool_node_count_min = 1
+aks_system_node_pool_node_count_max = 1
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
 reverse_proxy_ip = "10.1.1.250"
 
@@ -88,6 +87,11 @@ docker_registry = {
     enabled                   = false
     regional_endpoint_enabled = false
     zone_redundancy_enabled   = false
+  }
+  network_rule_set = {
+    default_action  = "Deny"
+    ip_rule         = []
+    virtual_network = []
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

- Fix the discrepancy between CIDR_subnet in Terraform template and existing configurations for every environment.
- Added network_rule_set to docker_registry_common for alignment with active configuration

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
