### PR TITLE
added FD ips to eventhub rules and created event hub accounts for FD …

### DIFF
--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -273,7 +273,7 @@ eventhubs = [{
   ]
 },{
   name              = "Selfcare-FD"
-  partitions        = 30
+  partitions        = 5
   message_retention = 7
   consumers         = []
   keys = [

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -267,7 +267,7 @@ eventhubs = [{
     {
       name   = "external-interceptor"
       listen = true
-      send   = true
+      send   = false
       manage = false
     }
   ]

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -198,7 +198,28 @@ eventhub_ip_rules = [
   { // SAP
     ip_mask = "3.65.9.91",
     action  = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.226.5/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.226.15/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.224.5/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.224.15/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "2.228.86.218/32",
+    action = "Allow"
   }
+
 ]
 
 eventhubs = [{
@@ -239,6 +260,18 @@ eventhubs = [{
     },
     {
       name   = "sap"
+      listen = true
+      send   = false
+      manage = false
+    },
+    {
+      name   = "external-interceptor"
+      listen = true
+      send   = true
+      manage = false
+    },
+    {
+      name   = "fd"
       listen = true
       send   = false
       manage = false

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -269,6 +269,19 @@ eventhubs = [{
       listen = true
       send   = true
       manage = false
+    }
+  ]
+},{
+  name              = "Selfcare-FD"
+  partitions        = 30
+  message_retention = 7
+  consumers         = []
+  keys = [
+    {
+      name   = "external-interceptor-wo"
+      listen = false
+      send   = true
+      manage = false
     },
     {
       name   = "fd"

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -307,7 +307,7 @@ eventhubs = [{
   ]
 },{
   name              = "Selfcare-FD"
-  partitions        = 30
+  partitions        = 6
   message_retention = 7
   consumers         = []
   keys = [

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -301,7 +301,7 @@ eventhubs = [{
     {
       name   = "external-interceptor"
       listen = true
-      send   = true
+      send   = false
       manage = false
     }
   ]

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -227,6 +227,26 @@ eventhub_ip_rules = [
   { // SAP
     ip_mask = "3.65.9.91",
     action  = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.226.5/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.226.15/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.224.5/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.224.15/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "2.228.86.218/32",
+    action = "Allow"
   }
 ]
 
@@ -274,6 +294,18 @@ eventhubs = [{
     },
     {
       name   = "test-io"
+      listen = true
+      send   = false
+      manage = false
+    },
+    {
+      name   = "external-interceptor"
+      listen = true
+      send   = true
+      manage = false
+    },
+    {
+      name   = "fd"
       listen = true
       send   = false
       manage = false

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -303,6 +303,19 @@ eventhubs = [{
       listen = true
       send   = true
       manage = false
+    }
+  ]
+},{
+  name              = "Selfcare-FD"
+  partitions        = 30
+  message_retention = 7
+  consumers         = []
+  keys = [
+    {
+      name   = "external-interceptor-wo"
+      listen = false
+      send   = true
+      manage = false
     },
     {
       name   = "fd"

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -345,6 +345,19 @@ eventhubs = [{
     {
       name   = "external-interceptor"
       listen = true
+      send   = false
+      manage = false
+    }
+  ]
+},{
+  name              = "Selfcare-FD"
+  partitions        = 30
+  message_retention = 7
+  consumers         = []
+  keys = [
+    {
+      name   = "external-interceptor-wo"
+      listen = false
       send   = true
       manage = false
     },

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -277,6 +277,26 @@ eventhub_ip_rules = [
   { // SAP
     ip_mask = "3.65.9.91",
     action  = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.226.5/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.226.15/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.224.5/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "91.218.224.15/32",
+    action = "Allow"
+  },
+  {//PROD-FD
+    ip_mask = "2.228.86.218/32",
+    action = "Allow"
   }
 ]
 
@@ -318,6 +338,18 @@ eventhubs = [{
     },
     {
       name   = "sap"
+      listen = true
+      send   = false
+      manage = false
+    },
+    {
+      name   = "external-interceptor"
+      listen = true
+      send   = true
+      manage = false
+    },
+    {
+      name   = "fd"
       listen = true
       send   = false
       manage = false

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -351,7 +351,7 @@ eventhubs = [{
   ]
 },{
   name              = "Selfcare-FD"
-  partitions        = 30
+  partitions        = 5
   message_retention = 7
   consumers         = []
   keys = [

--- a/src/k8s/00_secrets.tf
+++ b/src/k8s/00_secrets.tf
@@ -32,7 +32,7 @@ module "key_vault_secrets_query" {
     "jwt-secret",
     "eventhub-SC-Contracts-selfcare-wo-connection-string",
     "eventhub-SC-Contracts-interceptor-connection-string",
-    "eventhub-Selfcare-FD-external-interceptor-connection-string",
+    "eventhub-Selfcare-FD-external-interceptor-wo-connection-string",
     "external-api-key",
     "external-user-api",
     "user-registry-api-key",

--- a/src/k8s/00_secrets.tf
+++ b/src/k8s/00_secrets.tf
@@ -32,6 +32,7 @@ module "key_vault_secrets_query" {
     "jwt-secret",
     "eventhub-SC-Contracts-selfcare-wo-connection-string",
     "eventhub-SC-Contracts-interceptor-connection-string",
+    "eventhub-Selfcare-FD-external-interceptor-connection-string",
     "external-api-key",
     "external-user-api",
     "user-registry-api-key",
@@ -45,6 +46,7 @@ module "key_vault_secrets_query" {
     "infocamere-secret-private-key",
     "infocamere-secret-certificate",
     "onboarding-interceptor-apim-internal",
+    "external-interceptor-apim-internal",
     "national-registry-api-key",
     "geotaxonomy-api-key"
   ]

--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -287,6 +287,25 @@ resource "kubernetes_secret" "onboarding-interceptor-event-secrets" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret" "external-interceptor-event-secrets" {
+  metadata {
+    name      = "external-interceptor-event-secrets"
+    namespace = kubernetes_namespace.selc.metadata[0].name
+  }
+
+  data = {
+    KAFKA_BROKER            = "${local.project}-eventhub-ns.servicebus.windows.net:9093"
+    KAFKA_SECURITY_PROTOCOL = "SASL_SSL"
+    KAFKA_SASL_MECHANISM    = "PLAIN"
+
+    KAFKA_CONTRACTS_TOPIC                        = "SC-Contracts"
+    KAFKA_FD_TOPIC                               = "Selfcare-FD"
+    KAFKA_CONTRACTS_SELFCARE_RO_SASL_JAAS_CONFIG = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"${module.key_vault_secrets_query.values["eventhub-SC-Contracts-interceptor-connection-string"].value}\";"
+    KAFKA_SELFCARE_FD_WO_SASL_JAAS_CONFIG = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"${module.key_vault_secrets_query.values["eventhub-Selfcare-FD-WO-external-interceptor-connection-string"].value}\";"
+  }
+
+}
+
 resource "kubernetes_secret" "onboarding-interceptor-apim-internal" {
   metadata {
     name      = "onboarding-interceptor-apim-internal"
@@ -295,6 +314,19 @@ resource "kubernetes_secret" "onboarding-interceptor-apim-internal" {
 
   data = {
     SELFCARE_APIM_INTERNAL_API_KEY = module.key_vault_secrets_query.values["onboarding-interceptor-apim-internal"].value
+  }
+
+  type = "Opaque"
+}
+
+resource "kubernetes_secret" "external-interceptor-apim-internal" {
+  metadata {
+    name      = "external-interceptor-apim-internal"
+    namespace = kubernetes_namespace.selc.metadata[0].name
+  }
+
+  data = {
+    SELFCARE_APIM_INTERNAL_API_KEY = module.key_vault_secrets_query.values["external-interceptor-apim-internal"].value
   }
 
   type = "Opaque"

--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -301,7 +301,7 @@ resource "kubernetes_secret" "external-interceptor-event-secrets" {
     KAFKA_CONTRACTS_TOPIC                        = "SC-Contracts"
     KAFKA_FD_TOPIC                               = "Selfcare-FD"
     KAFKA_CONTRACTS_SELFCARE_RO_SASL_JAAS_CONFIG = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"${module.key_vault_secrets_query.values["eventhub-SC-Contracts-interceptor-connection-string"].value}\";"
-    KAFKA_SELFCARE_FD_WO_SASL_JAAS_CONFIG = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"${module.key_vault_secrets_query.values["eventhub-Selfcare-FD-WO-external-interceptor-connection-string"].value}\";"
+    KAFKA_SELFCARE_FD_WO_SASL_JAAS_CONFIG = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"${module.key_vault_secrets_query.values["eventhub-Selfcare-FD-external-interceptor-wo-connection-string"].value}\";"
   }
 
 }


### PR DESCRIPTION
…and external interceptor

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Adding prod-fd ips to eventhub ip rules, and creating write access account for external-interceptor microservice and read access account for prod-fd
Creating connection string secret for external interceptor
Creating new Topic for publishing events related to Fideiussioni Digitali
### Motivation and context

This will grant access to external product Fideiussioni digitali to read the events from the new Topic that will be dedicated for it, and will allow the new interceptor microservice to read from SCcontracts and publish to the new selfcare-fd topic

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
