### PR TITLE
Added secrets for backoffice pago pa

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -221,7 +221,6 @@
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.aks_to_acr](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.client_eventhub_access](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.eventhub_access](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.external_oauth2_issuer_apim_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_storage_container.selc-contracts-container](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.selc_logs_container](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -221,7 +221,7 @@ eventhub_ip_rules = [
   },
   { // FD
     ip_mask = "193.203.230.25",
-    action = "Allow"
+    action  = "Allow"
   },
   # {//PROD-FD
   #   ip_mask = "91.218.226.15/32",

--- a/src/k8s/00_secrets.tf
+++ b/src/k8s/00_secrets.tf
@@ -55,6 +55,7 @@ module "key_vault_secrets_query" {
     "eventhub-SC-Users-datalake-connection-string",
     "eventhub-SC-Users-external-interceptor-connection-string",
     "eventhub-SC-Contracts-sap-external-interceptor-wo-connection-string",
-    "eventhub-SC-Contracts-sap-sap-connection-string"
+    "eventhub-SC-Contracts-sap-sap-connection-string",
+    "pagopa-backoffice-api-key"
   ]
 }

--- a/src/k8s/README.md
+++ b/src/k8s/README.md
@@ -198,6 +198,7 @@ pre-commit run -a
 | [kubernetes_secret.national-registry-secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.onboarding-interceptor-apim-internal](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.onboarding-interceptor-event-secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.pagopa-backoffice-secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.postgres](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.product-external-api](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.selc-application-insights](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |

--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -395,3 +395,17 @@ resource "kubernetes_secret" "geotaxonomy-secrets" {
 
   type = "Opaque"
 }
+
+resource "kubernetes_secret" "pagopa-backoffice-secrets" {
+  metadata {
+    name      = "pagopa-backoffice-secrets"
+    namespace = kubernetes_namespace.selc.metadata[0].name
+  }
+
+  data = {
+    BACKOFFICE_PAGO_PA_API_KEY      = module.key_vault_secrets_query.values["pagopa-backoffice-api-key"].value
+  }
+
+  type = "Opaque"
+}
+

--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -403,7 +403,7 @@ resource "kubernetes_secret" "pagopa-backoffice-secrets" {
   }
 
   data = {
-    BACKOFFICE_PAGO_PA_API_KEY      = module.key_vault_secrets_query.values["pagopa-backoffice-api-key"].value
+    BACKOFFICE_PAGO_PA_API_KEY = module.key_vault_secrets_query.values["pagopa-backoffice-api-key"].value
   }
 
   type = "Opaque"


### PR DESCRIPTION
### List of changes

Added new secret for backoffice pagopa subscription key.

### Motivation and context

This change is necessary to allow dashboard-backend microservice to invoke backoffice apis.

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No