### PR TITLE
fix: pnpg storage credentials for sending mail

### DIFF
--- a/src/domains/pnpg-app/10_selc_secrets.tf
+++ b/src/domains/pnpg-app/10_selc_secrets.tf
@@ -117,11 +117,11 @@ resource "kubernetes_secret" "contracts-storage" {
 
   data = {
     STORAGE_TYPE               = "BlobStorage"
-    STORAGE_CONTAINER          = local.contracts_storage_container
+    STORAGE_CONTAINER          = "$web"
     STORAGE_ENDPOINT           = "core.windows.net"
     STORAGE_APPLICATION_ID     = local.contracts_storage_account_name
     STORAGE_APPLICATION_SECRET = module.key_vault_secrets_query.values["contracts-storage-access-key"].value
-    STORAGE_CREDENTIAL_ID      = local.contracts_storage_account_name
+    STORAGE_CREDENTIAL_ID      = "selc${var.env_short}weupnpgcheckoutsa"
     STORAGE_CREDENTIAL_SECRET  = module.key_vault_secrets_query.values["contracts-storage-access-key"].value
     STORAGE_TEMPLATE_URL       = format("https://selc%sweupnpgcheckoutsa.z6.web.core.windows.net", var.env_short)
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

set storage credentials for retrieving template and sending mail

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Move sending mail @ms-core

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
