### PR TITLE
Fix parameter for auto approval onboarding into open-api

### DIFF
--- a/src/core/api/ms_internal_api/v1/open-api.yml.tpl
+++ b/src/core/api/ms_internal_api/v1/open-api.yml.tpl
@@ -275,6 +275,13 @@ paths:
       summary: onboarding
       description: The service allows the onboarding of Users to a subunit of an Institution
       operationId: onboardingUsingPOST
+      parameters:
+          - name: x-selfcare-uid
+            in: header
+            description: Logged user's unique identifier
+            required: true
+            schema:
+              type: string
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
### List of changes

Added x-selfcare-uid into open-api for auto approval onboarding.

### Motivation and context

This parameter is necessary to retrieve authentication and test api into apim

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No