### PR TITLE
Add infra for GH self hosted runner on Azure Container App

### DIFF
--- a/src/core/.terraform.lock.hcl
+++ b/src/core/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "1.9.0"
+  constraints = "<= 1.9.0"
+  hashes = [
+    "h1:Ow1rr5fYBGSkplH/kcXeWz9y2wA81BnhZ7vTBzJfAAg=",
+    "h1:shpEoqcAbf+p6AvspiYO1YrX//8l1LV/owEcQpujWHw=",
+    "h1:yIJQVdnmGZdvS3yrw0M8ke9KiB/c0tjZ7KUXC46Hjx0=",
+    "h1:zaLH2Owmj61RX2G1Cy6VDy8Ttfzx+lDsSCyiu5cXkm4=",
+    "zh:349569471fbf387feaaf8b88da1690669e201147c342f905e5eb03df42b3cf87",
+    "zh:54346d5fb78cbad3eb7cfd96e1dd7ce4f78666cabaaccfec6ee9437476330018",
+    "zh:64b799da915ea3a9a58ac7a926c6a31c59fd0d911687804d8e815eda88c5580b",
+    "zh:9336ed9e112555e0fda8af6be9ba21478e30117d79ba662233311d9560d2b7c6",
+    "zh:a8aace9897b28ea0b2dbd7a3be3df033e158af40412c9c7670be0956f216ed7e",
+    "zh:ab23df7de700d9e785009a4ca9ceb38ae1ab894a13f5788847f15d018556f415",
+    "zh:b4f13f0b13560a67d427c71c85246f8920f98987120341830071df4535842053",
+    "zh:e58377bf36d8a14d28178a002657865ee17446182dac03525fd43435e41a1b5c",
+    "zh:ea5db4acc6413fd0fe6b35981e58cdc9850f5f3118031cc3d2581de511aee6aa",
+    "zh:f0b32c06c6bd4e4af2c02a62be07b947766aeeb09289a03f21aba16c2fd3c60f",
+    "zh:f1518e766a90c257d7eb36d360dafaf311593a4a9352ff8db0bcfe0ed8cf45ae",
+    "zh:fa89e84cff0776b5b61ff27049b1d8ed52040bd58c81c4628890d644a6fb2989",
+  ]
+}
+
 provider "registry.terraform.io/chilicat/pkcs12" {
   version     = "0.0.7"
   constraints = "0.0.7"

--- a/src/core/00_github_runner.tf
+++ b/src/core/00_github_runner.tf
@@ -1,0 +1,120 @@
+resource "azurerm_resource_group" "github_runner" {
+  name     = "${local.project}-github-runner-rg"
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_subnet" "github_runner" {
+  name                 = "${local.project}-github-runner-snet"
+  resource_group_name  = azurerm_resource_group.rg_vnet.name
+  virtual_network_name = module.vnet.name
+  address_prefixes     = var.cidr_subnet_gh_runner
+  service_endpoints = [
+    # "Microsoft.Web",
+  ]
+}
+
+module "github_runner" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//container_app_environment?ref=v6.15.0"
+
+  name                      = "${local.project}-github-runner-cae"
+  resource_group_name       = azurerm_resource_group.github_runner.name
+  location                  = var.location
+  vnet_internal             = true
+  subnet_id                 = azurerm_subnet.github_runner.id
+  log_destination           = "log-analytics"
+  log_analytics_customer_id = azurerm_log_analytics_workspace.log_analytics_workspace.workspace_id
+  log_analytics_shared_key  = azurerm_log_analytics_workspace.log_analytics_workspace.primary_shared_key
+  zone_redundant            = true
+
+  tags = var.tags
+}
+
+locals {
+  repo_owner = "PagoPA"
+  repo_name  = "selfcare-infra"
+  image_name = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47"
+}
+
+data "azurerm_key_vault_secret" "github_pat_selfcare_infra" {
+  name         = "github-pat-selfcare-infra"
+  key_vault_id = module.key_vault.id
+}
+
+resource "azapi_resource" "github_runner_job" {
+  type      = "Microsoft.App/jobs@2023-05-01"
+  name      = "${local.project}-github-runner-job"
+  location  = var.location
+  parent_id = azurerm_resource_group.github_runner.id
+
+  body = jsonencode({
+    properties = {
+      configuration = {
+        replicaRetryLimit = 1
+        replicaTimeout    = 1800
+        eventTriggerConfig = {
+          parallelism            = 1
+          replicaCompletionCount = 1
+          scale = {
+            maxExecutions   = 10
+            minExecutions   = 0
+            pollingInterval = 20
+            rules = [
+              {
+                name = "github-runner"
+                type = "github-runner"
+                metadata = {
+                  github_runner             = "https://api.github.com"
+                  owner                     = local.repo_owner
+                  runnerScope               = "repo"
+                  repos                     = local.repo_name
+                  targetWorkflowQueueLength = "1"
+                }
+                auth = [
+                  {
+                    secretRef        = "personal-access-token"
+                    triggerParameter = "personalAccessToken"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        secrets = [
+          {
+            name  = "personal-access-token"
+            value = "${data.azurerm_key_vault_secret.github_pat_selfcare_infra.value}"
+          }
+        ]
+        triggerType = "Event"
+      }
+      environmentId = module.github_runner.id
+      template = {
+        containers = [
+          {
+            env = [
+              {
+                name      = "GITHUB_PAT"
+                secretRef = "personal-access-token"
+              },
+              {
+                name  = "REPO_URL"
+                value = "https://github.com/${local.repo_owner}/${local.repo_name}"
+              },
+              {
+                name  = "REGISTRATION_TOKEN_API_URL"
+                value = "https://api.github.com/repos/${local.repo_owner}/${local.repo_name}/actions/runners/registration-token"
+              }
+            ]
+            image = local.image_name
+            name  = "github-actions-runner-job"
+            resources = {
+              cpu    = 0.5
+              memory = "1Gi"
+            }
+          }
+      ] }
+    }
+  })
+}

--- a/src/core/00_github_runner.tf
+++ b/src/core/00_github_runner.tf
@@ -10,9 +10,7 @@ resource "azurerm_subnet" "github_runner" {
   resource_group_name  = azurerm_resource_group.rg_vnet.name
   virtual_network_name = module.vnet.name
   address_prefixes     = var.cidr_subnet_gh_runner
-  service_endpoints = [
-    # "Microsoft.Web",
-  ]
+  service_endpoints    = []
 }
 
 module "github_runner" {
@@ -32,7 +30,7 @@ module "github_runner" {
 }
 
 locals {
-  repo_owner = "PagoPA"
+  repo_owner = "pagopa"
   repo_name  = "selfcare-infra"
   image_name = "ghcr.io/pagopa/github-self-hosted-runner-azure:beta-dockerfile-v2@sha256:ed51ac419d78b6410be96ecaa8aa8dbe645aa0309374132886412178e2739a47"
 }

--- a/src/core/99_main.tf
+++ b/src/core/99_main.tf
@@ -10,6 +10,11 @@ terraform {
       version = ">= 2.33.0"
     }
 
+    azapi = {
+      source  = "azure/azapi"
+      version = "<= 1.9.0"
+    }
+
     pkcs12 = {
       source  = "chilicat/pkcs12"
       version = "0.0.7"
@@ -19,7 +24,6 @@ terraform {
       source  = "hashicorp/random"
       version = "<= 3.5.1"
     }
-
   }
 
   backend "azurerm" {}
@@ -32,6 +36,8 @@ provider "azurerm" {
     }
   }
 }
+
+provider "azapi" {}
 
 data "azurerm_subscription" "current" {}
 

--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -550,6 +550,11 @@ variable "cidr_subnet_private_endpoints" {
   description = "private endpoints address space."
 }
 
+variable "cidr_subnet_gh_runner" {
+  type        = list(string)
+  description = "Container App Environment address space."
+}
+
 # DNS
 variable "dns_default_ttl_sec" {
   type        = number

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -34,6 +34,7 @@ cidr_subnet_logs_storage          = ["10.1.139.0/24"]
 cidr_subnet_pnpg_cosmosdb_mongodb = ["10.1.140.0/24"] #this is a place holder for pnpg mongo
 cidr_subnet_private_endpoints     = ["10.1.141.0/24"]
 cidr_subnet_load_tests            = ["10.1.142.0/24"]
+cidr_subnet_gh_runner             = ["10.1.146.0/23"]
 
 #
 # Pair VNET

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -34,6 +34,7 @@ cidr_subnet_logs_storage          = ["10.1.139.0/24"]
 cidr_subnet_private_endpoints     = ["10.1.140.0/24"]
 cidr_subnet_pnpg_cosmosdb_mongodb = ["10.1.141.0/24"] #this is a place holder for pnpg mongo
 cidr_subnet_load_tests            = ["10.1.142.0/29"]
+cidr_subnet_gh_runner             = ["10.1.144.0/23"]
 
 #
 # Pair VNET

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -34,6 +34,7 @@ cidr_subnet_logs_storage          = ["10.1.139.0/24"]
 cidr_subnet_private_endpoints     = ["10.1.140.0/24"]
 cidr_subnet_pnpg_cosmosdb_mongodb = ["10.1.141.0/24"] #this is a place holder for pnpg mongo
 cidr_subnet_load_tests            = ["10.1.142.0/24"]
+cidr_subnet_gh_runner             = ["10.1.144.0/23"]
 
 #
 # Pair VNET


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Terraform configuration for Azure Container App Job and related network environment

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Self hosted GitHub runners must run on Azure Container App jobs since they're easier to manage for developers and require less boilerplate in each pipeline

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
