### PR TITLE
compute_units_usage to Medium

### DIFF
--- a/src/core/04_appgateway.tf
+++ b/src/core/04_appgateway.tf
@@ -240,6 +240,7 @@ module "app_gw" {
     }
   ]
 
+
   # metrics docs
   # https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkapplicationgateways
   monitor_metric_alert_criteria = {
@@ -257,7 +258,7 @@ module "app_gw" {
           aggregation              = "Average"
           metric_name              = "ComputeUnits"
           operator                 = "GreaterOrLessThan"
-          alert_sensitivity        = "High"
+          alert_sensitivity        = "Medium"
           evaluation_total_count   = 2
           evaluation_failure_count = 2
           dimension                = []


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Set alert rule compute_units_usage sensitivity to Medium.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Alert rule compute_units_usage uses dynamic thresholds and it fires too much. Set the sensitivity to Medium to be more tolerant for deviations

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
