### PR TITLE
Refactor Identity Module

### DIFF
--- a/.identity/.terraform.lock.hcl
+++ b/.identity/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.45.0"
-  constraints = "<= 3.45.0"
+  constraints = ">= 3.30.0, <= 3.45.0, <= 3.71.0"
   hashes = [
     "h1:4BOYXFMiLk4ozEZHUhquRnE5urebcWvaCUV3uys646o=",
     "h1:V3CLlXij3vZzxw51hvCBnqriy73llPG21NjO+7sLr+U=",

--- a/.identity/01_github_identity.tf
+++ b/.identity/01_github_identity.tf
@@ -15,7 +15,7 @@ module "identity-ci" {
 
   ci_rbac_roles = {
     subscription    = var.environment_ci_roles.subscription
-    resource_groups = {}
+    resource_groups = var.environment_ci_roles.resource_groups
   }
 
   tags = var.tags
@@ -37,7 +37,7 @@ module "identity-cd" {
 
   ci_rbac_roles = {
     subscription    = var.environment_cd_roles.subscription
-    resource_groups = {}
+    resource_groups = var.environment_ci_roles.resource_groups
   }
 
   tags = var.tags

--- a/.identity/01_github_identity.tf
+++ b/.identity/01_github_identity.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "identity_rg" {
 }
 
 module "identity_ci" {
-  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=b9c9bfc42386034aa2f49a6a836955a12e715f48"
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.19.0"
 
   prefix    = var.prefix
   env_short = var.env_short
@@ -26,7 +26,7 @@ module "identity_ci" {
 }
 
 module "identity_cd" {
-  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=b9c9bfc42386034aa2f49a6a836955a12e715f48"
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=v7.19.0"
 
   prefix    = var.prefix
   env_short = var.env_short

--- a/.identity/01_github_identity.tf
+++ b/.identity/01_github_identity.tf
@@ -1,70 +1,38 @@
 resource "azurerm_resource_group" "identity_rg" {
-  name     = "identity-rg"
+  name     = "${local.project}-identity-rg"
   location = var.location
 }
 
-resource "azurerm_user_assigned_identity" "this_ci" {
-  location            = var.location
-  name                = "${local.app_name}-ci"
-  resource_group_name = azurerm_resource_group.identity_rg.name
+module "identity-ci" {
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=gh-identity-module"
+
+  prefix    = var.prefix
+  env_short = var.env_short
+
+  identity_role = "ci"
+
+  github_federations = var.github_federations
 
   tags = var.tags
+
+  depends_on = [
+    azurerm_resource_group.identity_rg
+  ]
 }
 
-resource "azurerm_user_assigned_identity" "this_cd" {
-  location            = var.location
-  name                = "${local.app_name}-cd"
-  resource_group_name = azurerm_resource_group.identity_rg.name
+module "identity-cd" {
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=gh-identity-module"
+
+  prefix    = var.prefix
+  env_short = var.env_short
+
+  identity_role = "cd"
+
+  github_federations = var.github_federations
 
   tags = var.tags
-}
 
-resource "azurerm_role_assignment" "environment_ci_subscription" {
-  for_each             = toset(var.environment_ci_roles.subscription)
-  scope                = data.azurerm_subscription.current.id
-  role_definition_name = each.key
-  principal_id         = azurerm_user_assigned_identity.this_ci.principal_id
-}
-
-resource "azurerm_role_assignment" "environment_cd_subscription" {
-  for_each             = toset(var.environment_cd_roles.subscription)
-  scope                = data.azurerm_subscription.current.id
-  role_definition_name = each.key
-  principal_id         = azurerm_user_assigned_identity.this_cd.principal_id
-}
-
-resource "azurerm_federated_identity_credential" "environment_ci" {
-  name                = "${local.project}-github-selfcare-infra-ci"
-  resource_group_name = azurerm_resource_group.identity_rg.name
-  audience            = var.github-federation.audience
-  issuer              = var.github-federation.issuer
-  parent_id           = azurerm_user_assigned_identity.this_ci.id
-  subject             = local.federation_subject_ci
-}
-
-resource "azurerm_federated_identity_credential" "environment_cd" {
-  name                = "${local.project}-github-selfcare-infra-cd"
-  resource_group_name = azurerm_resource_group.identity_rg.name
-  audience            = var.github-federation.audience
-  issuer              = var.github-federation.issuer
-  parent_id           = azurerm_user_assigned_identity.this_cd.id
-  subject             = local.federation_subject_cd
-}
-
-output "azure_environment_ci" {
-  value = {
-    app_name       = azurerm_user_assigned_identity.this_ci.name
-    client_id      = azurerm_user_assigned_identity.this_ci.client_id
-    application_id = azurerm_user_assigned_identity.this_ci.client_id
-    object_id      = azurerm_user_assigned_identity.this_ci.principal_id
-  }
-}
-
-output "azure_environment_cd" {
-  value = {
-    app_name       = azurerm_user_assigned_identity.this_cd.name
-    client_id      = azurerm_user_assigned_identity.this_cd.client_id
-    application_id = azurerm_user_assigned_identity.this_cd.client_id
-    object_id      = azurerm_user_assigned_identity.this_cd.principal_id
-  }
+  depends_on = [
+    azurerm_resource_group.identity_rg
+  ]
 }

--- a/.identity/01_github_identity.tf
+++ b/.identity/01_github_identity.tf
@@ -13,6 +13,11 @@ module "identity-ci" {
 
   github_federations = var.github_federations
 
+  ci_rbac_roles = {
+    subscription    = var.environment_ci_roles.subscription
+    resource_groups = {}
+  }
+
   tags = var.tags
 
   depends_on = [
@@ -29,6 +34,11 @@ module "identity-cd" {
   identity_role = "cd"
 
   github_federations = var.github_federations
+
+  ci_rbac_roles = {
+    subscription    = var.environment_cd_roles.subscription
+    resource_groups = {}
+  }
 
   tags = var.tags
 

--- a/.identity/01_github_identity.tf
+++ b/.identity/01_github_identity.tf
@@ -11,7 +11,7 @@ module "identity-ci" {
 
   identity_role = "ci"
 
-  github_federations = var.github_federations
+  github_federations = var.ci_github_federations
 
   ci_rbac_roles = {
     subscription    = var.environment_ci_roles.subscription
@@ -33,11 +33,11 @@ module "identity-cd" {
 
   identity_role = "cd"
 
-  github_federations = var.github_federations
+  github_federations = var.cd_github_federations
 
-  ci_rbac_roles = {
+  cd_rbac_roles = {
     subscription    = var.environment_cd_roles.subscription
-    resource_groups = var.environment_ci_roles.resource_groups
+    resource_groups = var.environment_cd_roles.resource_groups
   }
 
   tags = var.tags

--- a/.identity/01_github_identity.tf
+++ b/.identity/01_github_identity.tf
@@ -3,8 +3,8 @@ resource "azurerm_resource_group" "identity_rg" {
   location = var.location
 }
 
-module "identity-ci" {
-  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=gh-identity-module"
+module "identity_ci" {
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=b9c9bfc42386034aa2f49a6a836955a12e715f48"
 
   prefix    = var.prefix
   env_short = var.env_short
@@ -14,8 +14,8 @@ module "identity-ci" {
   github_federations = var.ci_github_federations
 
   ci_rbac_roles = {
-    subscription    = var.environment_ci_roles.subscription
-    resource_groups = var.environment_ci_roles.resource_groups
+    subscription_roles = var.environment_ci_roles.subscription
+    resource_groups    = var.environment_ci_roles.resource_groups
   }
 
   tags = var.tags
@@ -25,8 +25,8 @@ module "identity-ci" {
   ]
 }
 
-module "identity-cd" {
-  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=gh-identity-module"
+module "identity_cd" {
+  source = "github.com/pagopa/terraform-azurerm-v3//github_federated_identity?ref=b9c9bfc42386034aa2f49a6a836955a12e715f48"
 
   prefix    = var.prefix
   env_short = var.env_short
@@ -36,8 +36,8 @@ module "identity-cd" {
   github_federations = var.cd_github_federations
 
   cd_rbac_roles = {
-    subscription    = var.environment_cd_roles.subscription
-    resource_groups = var.environment_cd_roles.resource_groups
+    subscription_roles = var.environment_cd_roles.subscription
+    resource_groups    = var.environment_cd_roles.resource_groups
   }
 
   tags = var.tags

--- a/.identity/99_locals.tf
+++ b/.identity/99_locals.tf
@@ -1,7 +1,3 @@
 locals {
-  project  = "${var.prefix}-${var.env_short}"
-  app_name = "github-${var.github.org}-${var.github.repository}-${var.env}"
-
-  federation_subject_ci = "repo:${var.github.org}/${var.github.repository}:environment:${var.env}-ci"
-  federation_subject_cd = "repo:${var.github.org}/${var.github.repository}:environment:${var.env}-cd"
+  project = "${var.prefix}-${var.env_short}"
 }

--- a/.identity/99_variables.tf
+++ b/.identity/99_variables.tf
@@ -34,14 +34,16 @@ variable "github_federations" {
 
 variable "environment_ci_roles" {
   type = object({
-    subscription = list(string)
+    subscription    = list(string)
+    resource_groups = map(list(string))
   })
   description = "GitHub Continous Integration roles"
 }
 
 variable "environment_cd_roles" {
   type = object({
-    subscription = list(string)
+    subscription    = list(string)
+    resource_groups = map(list(string))
   })
   description = "GitHub Continous Delivery roles"
 }

--- a/.identity/99_variables.tf
+++ b/.identity/99_variables.tf
@@ -13,11 +13,6 @@ variable "location" {
   description = "One of westeurope, northeurope"
 }
 
-variable "env" {
-  type        = string
-  description = "Environment"
-}
-
 variable "env_short" {
   type = string
   validation {
@@ -28,26 +23,13 @@ variable "env_short" {
   }
 }
 
-variable "location_short" {
-  type = string
-  validation {
-    condition = (
-      length(var.location_short) <= 3
-    )
-    error_message = "Length must be 3 chars."
-  }
-}
-
-variable "github" {
-  type = object({
-    org        = string
-    repository = string
-  })
-  description = "GitHub Organization and repository name"
-  default = {
-    org        = "pagopa"
-    repository = "selfcare-infra"
-  }
+variable "github_federations" {
+  type = list(object({
+    repository        = string
+    credentials_scope = optional(string, "environment")
+    subject           = string
+  }))
+  description = "GitHub Organization, repository name and scope permissions"
 }
 
 variable "environment_ci_roles" {
@@ -62,18 +44,6 @@ variable "environment_cd_roles" {
     subscription = list(string)
   })
   description = "GitHub Continous Delivery roles"
-}
-
-variable "github-federation" {
-  description = "Static GitHub federation data"
-  type = object({
-    audience = list(string)
-    issuer   = string
-  })
-  default = {
-    audience = ["api://AzureADTokenExchange"]
-    issuer   = "https://token.actions.githubusercontent.com"
-  }
 }
 
 variable "tags" {

--- a/.identity/99_variables.tf
+++ b/.identity/99_variables.tf
@@ -23,7 +23,16 @@ variable "env_short" {
   }
 }
 
-variable "github_federations" {
+variable "ci_github_federations" {
+  type = list(object({
+    repository        = string
+    credentials_scope = optional(string, "environment")
+    subject           = string
+  }))
+  description = "GitHub Organization, repository name and scope permissions"
+}
+
+variable "cd_github_federations" {
   type = list(object({
     repository        = string
     credentials_scope = optional(string, "environment")

--- a/.identity/README.md
+++ b/.identity/README.md
@@ -11,8 +11,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_identity-cd"></a> [identity-cd](#module\_identity-cd) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | gh-identity-module |
-| <a name="module_identity-ci"></a> [identity-ci](#module\_identity-ci) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | gh-identity-module |
+| <a name="module_identity_cd"></a> [identity\_cd](#module\_identity\_cd) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | b9c9bfc42386034aa2f49a6a836955a12e715f48 |
+| <a name="module_identity_ci"></a> [identity\_ci](#module\_identity\_ci) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | b9c9bfc42386034aa2f49a6a836955a12e715f48 |
 
 ## Resources
 

--- a/.identity/README.md
+++ b/.identity/README.md
@@ -27,8 +27,8 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
-| <a name="input_environment_cd_roles"></a> [environment\_cd\_roles](#input\_environment\_cd\_roles) | GitHub Continous Delivery roles | <pre>object({<br>    subscription = list(string)<br>  })</pre> | n/a | yes |
-| <a name="input_environment_ci_roles"></a> [environment\_ci\_roles](#input\_environment\_ci\_roles) | GitHub Continous Integration roles | <pre>object({<br>    subscription = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_environment_cd_roles"></a> [environment\_cd\_roles](#input\_environment\_cd\_roles) | GitHub Continous Delivery roles | <pre>object({<br>    subscription    = list(string)<br>    resource_groups = map(list(string))<br>  })</pre> | n/a | yes |
+| <a name="input_environment_ci_roles"></a> [environment\_ci\_roles](#input\_environment\_ci\_roles) | GitHub Continous Integration roles | <pre>object({<br>    subscription    = list(string)<br>    resource_groups = map(list(string))<br>  })</pre> | n/a | yes |
 | <a name="input_github_federations"></a> [github\_federations](#input\_github\_federations) | GitHub Organization, repository name and scope permissions | <pre>list(object({<br>    repository        = string<br>    credentials_scope = optional(string, "environment")<br>    subject           = string<br>  }))</pre> | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | One of westeurope, northeurope | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |

--- a/.identity/README.md
+++ b/.identity/README.md
@@ -11,8 +11,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_identity_cd"></a> [identity\_cd](#module\_identity\_cd) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | b9c9bfc42386034aa2f49a6a836955a12e715f48 |
-| <a name="module_identity_ci"></a> [identity\_ci](#module\_identity\_ci) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | b9c9bfc42386034aa2f49a6a836955a12e715f48 |
+| <a name="module_identity_cd"></a> [identity\_cd](#module\_identity\_cd) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | v7.19.0 |
+| <a name="module_identity_ci"></a> [identity\_ci](#module\_identity\_ci) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | v7.19.0 |
 
 ## Resources
 

--- a/.identity/README.md
+++ b/.identity/README.md
@@ -26,10 +26,11 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cd_github_federations"></a> [cd\_github\_federations](#input\_cd\_github\_federations) | GitHub Organization, repository name and scope permissions | <pre>list(object({<br>    repository        = string<br>    credentials_scope = optional(string, "environment")<br>    subject           = string<br>  }))</pre> | n/a | yes |
+| <a name="input_ci_github_federations"></a> [ci\_github\_federations](#input\_ci\_github\_federations) | GitHub Organization, repository name and scope permissions | <pre>list(object({<br>    repository        = string<br>    credentials_scope = optional(string, "environment")<br>    subject           = string<br>  }))</pre> | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_environment_cd_roles"></a> [environment\_cd\_roles](#input\_environment\_cd\_roles) | GitHub Continous Delivery roles | <pre>object({<br>    subscription    = list(string)<br>    resource_groups = map(list(string))<br>  })</pre> | n/a | yes |
 | <a name="input_environment_ci_roles"></a> [environment\_ci\_roles](#input\_environment\_ci\_roles) | GitHub Continous Integration roles | <pre>object({<br>    subscription    = list(string)<br>    resource_groups = map(list(string))<br>  })</pre> | n/a | yes |
-| <a name="input_github_federations"></a> [github\_federations](#input\_github\_federations) | GitHub Organization, repository name and scope permissions | <pre>list(object({<br>    repository        = string<br>    credentials_scope = optional(string, "environment")<br>    subject           = string<br>  }))</pre> | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | One of westeurope, northeurope | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |

--- a/.identity/README.md
+++ b/.identity/README.md
@@ -9,19 +9,16 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_identity-cd"></a> [identity-cd](#module\_identity-cd) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | gh-identity-module |
+| <a name="module_identity-ci"></a> [identity-ci](#module\_identity-ci) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | gh-identity-module |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [azurerm_federated_identity_credential.environment_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
-| [azurerm_federated_identity_credential.environment_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_resource_group.identity_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.environment_cd_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.environment_ci_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_user_assigned_identity.this_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.this_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
@@ -29,21 +26,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_env"></a> [env](#input\_env) | Environment | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_environment_cd_roles"></a> [environment\_cd\_roles](#input\_environment\_cd\_roles) | GitHub Continous Delivery roles | <pre>object({<br>    subscription = list(string)<br>  })</pre> | n/a | yes |
 | <a name="input_environment_ci_roles"></a> [environment\_ci\_roles](#input\_environment\_ci\_roles) | GitHub Continous Integration roles | <pre>object({<br>    subscription = list(string)<br>  })</pre> | n/a | yes |
-| <a name="input_github"></a> [github](#input\_github) | GitHub Organization and repository name | <pre>object({<br>    org        = string<br>    repository = string<br>  })</pre> | <pre>{<br>  "org": "pagopa",<br>  "repository": "selfcare-infra"<br>}</pre> | no |
-| <a name="input_github-federation"></a> [github-federation](#input\_github-federation) | Static GitHub federation data | <pre>object({<br>    audience = list(string)<br>    issuer   = string<br>  })</pre> | <pre>{<br>  "audience": [<br>    "api://AzureADTokenExchange"<br>  ],<br>  "issuer": "https://token.actions.githubusercontent.com"<br>}</pre> | no |
+| <a name="input_github_federations"></a> [github\_federations](#input\_github\_federations) | GitHub Organization, repository name and scope permissions | <pre>list(object({<br>    repository        = string<br>    credentials_scope = optional(string, "environment")<br>    subject           = string<br>  }))</pre> | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | One of westeurope, northeurope | `string` | n/a | yes |
-| <a name="input_location_short"></a> [location\_short](#input\_location\_short) | n/a | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_azure_environment_cd"></a> [azure\_environment\_cd](#output\_azure\_environment\_cd) | n/a |
-| <a name="output_azure_environment_ci"></a> [azure\_environment\_ci](#output\_azure\_environment\_ci) | n/a |
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/.identity/env/dev/backend.tfvars
+++ b/.identity/env/dev/backend.tfvars
@@ -1,4 +1,4 @@
 resource_group_name  = "terraform-state-rg"
-storage_account_name = "tfappdevselfcare"
+storage_account_name = "tfinfdevselfcare"
 container_name       = "terraform-state"
 key                  = "selfcare-infra.identity.tfstate"

--- a/.identity/env/dev/terraform.tfvars
+++ b/.identity/env/dev/terraform.tfvars
@@ -32,6 +32,10 @@ cd_github_federations = [
     subject    = "DEV"
   },
   {
+    repository = "selfcare-infra"
+    subject    = "dev-cd"
+  },
+  {
     repository = "selfcare-onboarding"
     subject    = "dev-cd"
   }

--- a/.identity/env/dev/terraform.tfvars
+++ b/.identity/env/dev/terraform.tfvars
@@ -17,6 +17,10 @@ ci_github_federations = [
     subject    = "DEV"
   },
   {
+    repository = "selfcare-infra"
+    subject    = "dev-ci"
+  },
+  {
     repository = "selfcare-onboarding"
     subject    = "dev-ci"
   }
@@ -41,14 +45,21 @@ environment_ci_roles = {
     "Storage File Data SMB Share Reader",
     "Storage Queue Data Reader",
     "Storage Table Data Reader",
-    "PagoPA Export Deployments Template",
     "Key Vault Secrets User",
     "DocumentDB Account Contributor",
-    "API Management Service Contributor"
+    "API Management Service Contributor",
+    "PagoPA Export Deployments Template",
+    "PagoPA IaC Reader"
   ]
   resource_groups = {
     "terraform-state-rg" = [
       "Storage Blob Data Contributor"
+    ],
+    "io-infra-rg" = [
+      "Storage Blob Data Contributor"
+    ],
+    "selc-d-aks-rg" = [
+      "Azure Kubernetes Service Cluster Admin Role"
     ]
   }
 }
@@ -64,7 +75,13 @@ environment_cd_roles = {
   ]
   resource_groups = {
     "terraform-state-rg" = [
-      "Storage Blob Data Owner"
+      "Storage Blob Data Contributor"
+    ],
+    "io-infra-rg" = [
+      "Storage Blob Data Contributor"
+    ],
+    "selc-d-aks-rg" = [
+      "Azure Kubernetes Service Cluster Admin Role"
     ]
   }
 }

--- a/.identity/env/dev/terraform.tfvars
+++ b/.identity/env/dev/terraform.tfvars
@@ -1,9 +1,7 @@
 # general
-prefix         = "selfcare"
-env_short      = "d"
-env            = "dev"
-location       = "westeurope"
-location_short = "weu"
+prefix    = "selc"
+env_short = "d"
+location  = "westeurope"
 
 tags = {
   CreatedBy   = "Terraform"
@@ -12,6 +10,17 @@ tags = {
   Source      = "https://github.com/pagopa/selfcare-infra"
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
+
+github_federations = [
+  {
+    repository = "selfcare-infra"
+    subject    = "DEV"
+  },
+  {
+    repository = "selfcare-onboarding"
+    subject    = "dev"
+  }
+]
 
 environment_ci_roles = {
   subscription = [

--- a/.identity/env/dev/terraform.tfvars
+++ b/.identity/env/dev/terraform.tfvars
@@ -11,14 +11,25 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
-github_federations = [
+ci_github_federations = [
   {
     repository = "selfcare-infra"
     subject    = "DEV"
   },
   {
     repository = "selfcare-onboarding"
-    subject    = "dev"
+    subject    = "dev-ci"
+  }
+]
+
+cd_github_federations = [
+  {
+    repository = "selfcare-infra"
+    subject    = "DEV"
+  },
+  {
+    repository = "selfcare-onboarding"
+    subject    = "dev-cd"
   }
 ]
 
@@ -37,7 +48,7 @@ environment_ci_roles = {
   ]
   resource_groups = {
     "terraform-state-rg" = [
-      "Storage Blob Data Owner"
+      "Storage Blob Data Contributor"
     ]
   }
 }
@@ -49,7 +60,11 @@ environment_cd_roles = {
     "Storage Blob Data Contributor",
     "Storage File Data SMB Share Contributor",
     "Storage Queue Data Contributor",
-    "Storage Table Data Contributor",
+    "Storage Table Data Contributor"
   ]
-  resource_groups = {}
+  resource_groups = {
+    "terraform-state-rg" = [
+      "Storage Blob Data Owner"
+    ]
+  }
 }

--- a/.identity/env/dev/terraform.tfvars
+++ b/.identity/env/dev/terraform.tfvars
@@ -33,8 +33,13 @@ environment_ci_roles = {
     "PagoPA Export Deployments Template",
     "Key Vault Secrets User",
     "DocumentDB Account Contributor",
-    "API Management Service Contributor",
+    "API Management Service Contributor"
   ]
+  resource_groups = {
+    "terraform-state-rg" = [
+      "Storage Blob Data Owner"
+    ]
+  }
 }
 
 environment_cd_roles = {
@@ -46,4 +51,5 @@ environment_cd_roles = {
     "Storage Queue Data Contributor",
     "Storage Table Data Contributor",
   ]
+  resource_groups = {}
 }

--- a/.identity/env/prod/backend.tfvars
+++ b/.identity/env/prod/backend.tfvars
@@ -1,4 +1,4 @@
 resource_group_name  = "terraform-state-rg"
-storage_account_name = "tfappprodselfcare"
+storage_account_name = "tfinfprodselfcare"
 container_name       = "terraform-state"
 key                  = "selfcare-infra.identity.tfstate"

--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -16,22 +16,30 @@ tags = {
 ci_github_federations = [
   {
     repository = "selfcare-infra"
-    subject    = "DEV"
+    subject    = "PROD"
+  },
+  {
+    repository = "selfcare-infra"
+    subject    = "prod-ci"
   },
   {
     repository = "selfcare-onboarding"
-    subject    = "dev-ci"
+    subject    = "prod-ci"
   }
 ]
 
 cd_github_federations = [
   {
     repository = "selfcare-infra"
-    subject    = "DEV"
+    subject    = "PROD"
+  },
+  {
+    repository = "selfcare-infra"
+    subject    = "prod-cd"
   },
   {
     repository = "selfcare-onboarding"
-    subject    = "dev-cd"
+    subject    = "prod-cd"
   }
 ]
 

--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -13,14 +13,25 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
-github_federations = [
+ci_github_federations = [
   {
     repository = "selfcare-infra"
     subject    = "DEV"
   },
   {
     repository = "selfcare-onboarding"
-    subject    = "dev"
+    subject    = "dev-ci"
+  }
+]
+
+cd_github_federations = [
+  {
+    repository = "selfcare-infra"
+    subject    = "DEV"
+  },
+  {
+    repository = "selfcare-onboarding"
+    subject    = "dev-cd"
   }
 ]
 

--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -13,6 +13,17 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
+github_federations = [
+  {
+    repository = "selfcare-infra"
+    subject    = "DEV"
+  },
+  {
+    repository = "selfcare-onboarding"
+    subject    = "dev"
+  }
+]
+
 environment_ci_roles = {
   subscription = [
     "Reader",

--- a/.identity/env/uat/backend.tfvars
+++ b/.identity/env/uat/backend.tfvars
@@ -1,4 +1,4 @@
 resource_group_name  = "terraform-state-rg"
-storage_account_name = "tfappuatselfcare"
+storage_account_name = "tfinfuatselfcare"
 container_name       = "terraform-state"
 key                  = "selfcare-infra.identity.tfstate"

--- a/.identity/env/uat/terraform.tfvars
+++ b/.identity/env/uat/terraform.tfvars
@@ -16,22 +16,30 @@ tags = {
 ci_github_federations = [
   {
     repository = "selfcare-infra"
-    subject    = "DEV"
+    subject    = "UAT"
+  },
+  {
+    repository = "selfcare-infra"
+    subject    = "uat-ci"
   },
   {
     repository = "selfcare-onboarding"
-    subject    = "dev-ci"
+    subject    = "uat-ci"
   }
 ]
 
 cd_github_federations = [
   {
     repository = "selfcare-infra"
-    subject    = "DEV"
+    subject    = "UAT"
+  },
+  {
+    repository = "selfcare-infra"
+    subject    = "uat-cd"
   },
   {
     repository = "selfcare-onboarding"
-    subject    = "dev-cd"
+    subject    = "uat-cd"
   }
 ]
 

--- a/.identity/env/uat/terraform.tfvars
+++ b/.identity/env/uat/terraform.tfvars
@@ -13,14 +13,25 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
-github_federations = [
+ci_github_federations = [
   {
     repository = "selfcare-infra"
     subject    = "DEV"
   },
   {
     repository = "selfcare-onboarding"
-    subject    = "dev"
+    subject    = "dev-ci"
+  }
+]
+
+cd_github_federations = [
+  {
+    repository = "selfcare-infra"
+    subject    = "DEV"
+  },
+  {
+    repository = "selfcare-onboarding"
+    subject    = "dev-cd"
   }
 ]
 

--- a/.identity/env/uat/terraform.tfvars
+++ b/.identity/env/uat/terraform.tfvars
@@ -13,6 +13,17 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
+github_federations = [
+  {
+    repository = "selfcare-infra"
+    subject    = "DEV"
+  },
+  {
+    repository = "selfcare-onboarding"
+    subject    = "dev"
+  }
+]
+
 environment_ci_roles = {
   subscription = [
     "Reader",

--- a/src/core/01_key_vault_0.tf
+++ b/src/core/01_key_vault_0.tf
@@ -176,6 +176,11 @@ resource "azurerm_key_vault_access_policy" "github_identity_ci_policy" {
     "Get",
     "List",
   ]
+
+  certificate_permissions = [
+    "Get",
+    "List"
+  ]
 }
 
 resource "azurerm_key_vault_access_policy" "github_identity_cd_policy" {
@@ -186,5 +191,10 @@ resource "azurerm_key_vault_access_policy" "github_identity_cd_policy" {
   secret_permissions = [
     "Get",
     "List",
+  ]
+
+  certificate_permissions = [
+    "Get",
+    "List"
   ]
 }

--- a/src/core/01_key_vault_0.tf
+++ b/src/core/01_key_vault_0.tf
@@ -155,3 +155,36 @@ resource "azurerm_user_assigned_identity" "appgateway" {
   tags = var.tags
 }
 
+## github identity
+
+data "azurerm_user_assigned_identity" "identity_ci" {
+  resource_group_name = "${local.project}-identity-rg"
+  name                = "${local.project}-github-ci-identity"
+}
+
+data "azurerm_user_assigned_identity" "identity_cd" {
+  resource_group_name = "${local.project}-identity-rg"
+  name                = "${local.project}-github-cd-identity"
+}
+
+resource "azurerm_key_vault_access_policy" "github_identity_ci_policy" {
+  key_vault_id = module.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_user_assigned_identity.identity_ci.principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "github_identity_cd_policy" {
+  key_vault_id = module.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_user_assigned_identity.identity_cd.principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -151,6 +151,8 @@
 | [azurerm_key_vault_access_policy.azdevops_iac_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdo_sp_tls_cert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azure_cdn_frontdoor_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.github_identity_cd_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.github_identity_ci_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.application_insights_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.cosmosdb_account_mongodb_connection_strings](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.event_hub_connection_strings](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
@@ -283,6 +285,8 @@
 | [azurerm_key_vault_secret.sec_storage_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.sec_workspace_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_user_assigned_identity.identity_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
+| [azurerm_user_assigned_identity.identity_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [local_file.resources_anac_data_csv](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.resources_default_product_depict-image](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.resources_default_product_logo](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Remove duplicated code and add a reference to [this PR](https://github.com/pagopa/terraform-azurerm-v3/pull/165).
Add federated credentials for both selfcare-infra and selfcare-onboarding repos.
Replace terraform state file

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
More than a single repository shall be able to use the same managed identity dedicated to a specific domain/project. New module version already supports it, so it worths to refactor this module.

Ex terraform state file was definitely wrong. It's all about infra and not apps

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
