### PR TITLE
[SELC-3174] feat: added api onboarding users

### DIFF
--- a/src/core/api/selfcare_support_service/v1/open-api.yml.tpl
+++ b/src/core/api/selfcare_support_service/v1/open-api.yml.tpl
@@ -441,6 +441,49 @@ paths:
       security:
         - bearerAuth:
             - global
+  '/onboarding/users':
+    post:
+      tags:
+        - Onboarding
+      summary: The service adds users to the registry if they are not present and associates them with the institution and product contained in the body
+      description: The service adds users to the registry if they are not present and associates them with the institution and product contained in the body
+      operationId: onboardingInstitutionUsersUsingPOST
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnboardingInstitutionUsersRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RelationshipResult'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '409':
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      security:
+        - bearerAuth:
+            - global
+  
 components:
   schemas:
     InvalidParam:
@@ -1182,6 +1225,95 @@ components:
           type: string
         desc:
           type: string
+    OnboardingInstitutionUsersRequest:
+      title: OnboardingInstitutionUsersRequest
+      type: object
+      properties:
+        institutionSubunitCode:
+          type: string
+        institutionTaxCode:
+          type: string
+        productId:
+          type: string
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/Person'
+    Person:
+      title: Person
+      type: object
+      properties:
+        email:
+          type: string
+        env:
+          type: string
+          enum:
+            - COLL
+            - DEV
+            - PROD
+            - ROOT
+        id:
+          type: string
+        name:
+          type: string
+        productRole:
+          type: string
+        role:
+          type: string
+          enum:
+            - DELEGATE
+            - MANAGER
+            - OPERATOR
+            - SUB_DELEGATE
+        roleLabel:
+          type: string
+        surname:
+          type: string
+        taxCode:
+          type: string
+    RelationshipResult:
+      title: RelationshipResult
+      type: object
+      properties:
+        billing:
+          $ref: '#/components/schemas/BillingResponse'
+        createdAt:
+          type: string
+          format: date-time
+        from:
+          type: string
+        id:
+          type: string
+        institutionUpdate:
+          $ref: '#/components/schemas/InstitutionUpdate'
+        pricingPlan:
+          type: string
+        product:
+          $ref: '#/components/schemas/ProductInfo'
+        role:
+          type: string
+          enum:
+            - DELEGATE
+            - MANAGER
+            - OPERATOR
+            - SUB_DELEGATE
+        state:
+          type: string
+          enum:
+            - ACTIVE
+            - DELETED
+            - PENDING
+            - REJECTED
+            - SUSPENDED
+            - TOBEVALIDATED
+        to:
+          type: string
+        tokenId:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+     
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/core/api/selfcare_support_service/v1/postOnboardingInstitutionUsers_op_policy.xml.tpl
+++ b/src/core/api/selfcare_support_service/v1/postOnboardingInstitutionUsers_op_policy.xml.tpl
@@ -33,6 +33,7 @@
         <set-header name="Authorization" exists-action="override">
             <value>@((string)context.Variables["jwt"])</value>
         </set-header>
+        <set-backend-service base-url="${MS_CORE_BACKEND_BASE_URL}" />
     </inbound>
     <backend>
         <base />

--- a/src/core/api/selfcare_support_service/v1/postOnboardingInstitutionUsers_op_policy.xml.tpl
+++ b/src/core/api/selfcare_support_service/v1/postOnboardingInstitutionUsers_op_policy.xml.tpl
@@ -1,0 +1,46 @@
+<policies>
+    <inbound>
+        <base />
+        <set-variable name="jwt" value="@{
+            // 1) Construct the Base64Url-encoded header
+            var header = new { typ = "JWT", alg = "RS256", kid = "${KID}" };
+            var jwtHeaderBase64UrlEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(header))).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+            // As the header is a constant, you may use this equivalent Base64Url-encoded string instead to save the repetitive computation above.
+            // var jwtHeaderBase64UrlEncoded = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9";
+
+            // 2) Construct the Base64Url-encoded payload
+            var exp = new DateTimeOffset(DateTime.Now.AddMinutes(30)).ToUnixTimeSeconds();  // sets the expiration of the token to be 30 seconds from now
+            var uid = "m2m";
+
+
+            var aud = "${API_DOMAIN}";
+            var iss = "SPID";
+            var payload = new { exp, uid, aud, iss };
+            var jwtPayloadBase64UrlEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(payload))).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+
+            // 3) Construct the Base64Url-encoded signature
+            using (RSA rsa = context.Deployment.Certificates["${JWT_CERTIFICATE_THUMBPRINT}"].GetRSAPrivateKey())
+            {
+            byte[] data2sign = Encoding.UTF8.GetBytes($"{jwtHeaderBase64UrlEncoded}.{jwtPayloadBase64UrlEncoded}");
+            var signature = rsa.SignData(data2sign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);;
+            var jwtSignatureBase64UrlEncoded = Convert.ToBase64String(signature).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+
+            // 4) Return the HMAC SHA256-signed JWT as the value for the Authorization header
+            return $"Bearer {jwtHeaderBase64UrlEncoded}.{jwtPayloadBase64UrlEncoded}.{jwtSignatureBase64UrlEncoded}";
+            }
+
+            }"/>
+        <set-header name="Authorization" exists-action="override">
+            <value>@((string)context.Variables["jwt"])</value>
+        </set-header>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -893,6 +893,15 @@ module "apim_selfcare_support_service_v1" {
         KID                        = module.jwt.jwt_kid
         JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
       })
+    },
+    {
+      operation_id = "onboardingInstitutionUsersUsingPOST"
+      xml_content = templatefile("./api/selfcare_support_service/v1/postOnboardingInstitutionUsers_op_policy.xml.tpl", {
+        MS_CORE_BACKEND_BASE_URL   = "http://${var.reverse_proxy_ip}/ms-core/v1/"
+        API_DOMAIN                 = local.api_domain
+        KID                        = module.jwt.jwt_kid
+        JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
+      })
     }
   ]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Added api POST /onboarding/users that call ms-core/v1//onboarding/users

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This api adds users to the registry if they are not present and associates them with the institution and product contained in the body. It is useful for operations when we have to add SUB_DELEGATE to institution that has an onboarding on prod-interop
      

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
