### PR TITLE
Add TLS certificates to K8S for ingresses

### DIFF
--- a/.identity/README.md
+++ b/.identity/README.md
@@ -11,8 +11,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_identity_cd"></a> [identity\_cd](#module\_identity\_cd) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | v7.19.0 |
-| <a name="module_identity_ci"></a> [identity\_ci](#module\_identity\_ci) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | v7.19.0 |
+| <a name="module_identity_cd"></a> [identity\_cd](#module\_identity\_cd) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | v7.22.0 |
+| <a name="module_identity_ci"></a> [identity\_ci](#module\_identity\_ci) | github.com/pagopa/terraform-azurerm-v3//github_federated_identity | v7.22.0 |
 
 ## Resources
 

--- a/.identity/env/prod/terraform.tfvars
+++ b/.identity/env/prod/terraform.tfvars
@@ -1,7 +1,7 @@
 # general
-prefix         = "selc"
-env_short      = "p"
-location       = "westeurope"
+prefix    = "selc"
+env_short = "p"
+location  = "westeurope"
 
 tags = {
   CreatedBy   = "Terraform"

--- a/src/core/02_dns_public.tf
+++ b/src/core/02_dns_public.tf
@@ -176,7 +176,7 @@ resource "azurerm_dns_mx_record" "dns-mx-email-selfcare-pagopa-it" {
   tags = var.tags
 }
 
-# spf record 
+# spf record
 resource "azurerm_dns_txt_record" "dns-txt-email-selfcare-pagopa-it-aws-ses" {
   count               = var.env_short == "p" ? 1 : 0
   name                = "email"
@@ -226,5 +226,14 @@ resource "azurerm_dns_cname_record" "dkim-aws-ses-selfcare-pagopa-it" {
   resource_group_name = azurerm_resource_group.rg_vnet.name
   ttl                 = var.dns_default_ttl_sec
   record              = each.value.value
+  tags                = var.tags
+}
+
+resource "azurerm_dns_a_record" "selc_internal" {
+  name                = "selc.internal"
+  zone_name           = azurerm_dns_zone.selfcare_public[0].name
+  resource_group_name = azurerm_resource_group.rg_vnet.name
+  ttl                 = var.dns_default_ttl_sec
+  records             = [var.reverse_proxy_ip]
   tags                = var.tags
 }

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -131,6 +131,7 @@
 | [azurerm_dashboard.monitoring-dashboard](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dashboard) | resource |
 | [azurerm_dns_a_record.dns_a_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_a_record.public_api_pnpg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
+| [azurerm_dns_a_record.selc_internal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_caa_record.caa_selfcare](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
 | [azurerm_dns_cname_record.dkim-aws-ses-selfcare-pagopa-it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record) | resource |
 | [azurerm_dns_mx_record.dns-mx-email-selfcare-pagopa-it](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_mx_record) | resource |

--- a/src/k8s/.terraform.lock.hcl
+++ b/src/k8s/.terraform.lock.hcl
@@ -93,6 +93,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 provider "registry.terraform.io/integrations/github" {
   version = "5.40.0"
   hashes = [
+    "h1:BFga0rliQ6SklW0J7/78GRQ+tazszyeFx5xVLKhOqkQ=",
     "h1:DNmVzYxz8wlkrIe9gr+exwzCakE61UHXIn+qPq+5QRE=",
     "zh:02922b9eb54dcdbad524caaef7901a800759ae5d3a6c8cbdf934d4cfce395d5d",
     "zh:282b9736c2afa9f4a7817d5da9ac0caeddb4edc085c7236b71f3ecbb539b2132",

--- a/src/k8s/00_certificates.tf
+++ b/src/k8s/00_certificates.tf
@@ -1,0 +1,10 @@
+data "azurerm_key_vault" "key_vault" {
+  name                = local.key_vault_name
+  resource_group_name = local.key_vault_resource_group
+}
+
+data "azurerm_key_vault_certificate_data" "values" {
+  for_each     = var.secrets_tls_certificates
+  name         = each.value
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+}

--- a/src/k8s/99_variables.tf
+++ b/src/k8s/99_variables.tf
@@ -181,3 +181,7 @@ variable "location_string" {
 variable "configmaps_national_registries" {
   type = map(string)
 }
+
+variable "secrets_tls_certificates" {
+  type = set(string)
+}

--- a/src/k8s/README.md
+++ b/src/k8s/README.md
@@ -208,6 +208,7 @@ pre-commit run -a
 | [kubernetes_secret.pagopa-backoffice-secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.postgres](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.product-external-api](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.secret-tls-selc-internal](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.selc-application-insights](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.selc-redis-credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.social-login](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
@@ -225,6 +226,8 @@ pre-commit run -a
 | [azuread_group.adgroup_technical_project_managers](https://registry.terraform.io/providers/hashicorp/azuread/2.5.0/docs/data-sources/group) | data source |
 | [azurerm_application_insights.application_insights](https://registry.terraform.io/providers/hashicorp/azurerm/2.79.1/docs/data-sources/application_insights) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.79.1/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/2.79.1/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault_certificate_data.values](https://registry.terraform.io/providers/hashicorp/azurerm/2.79.1/docs/data-sources/key_vault_certificate_data) | data source |
 | [azurerm_kubernetes_cluster.aks](https://registry.terraform.io/providers/hashicorp/azurerm/2.79.1/docs/data-sources/kubernetes_cluster) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/2.79.1/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/2.79.1/docs/data-sources/monitor_action_group) | data source |
@@ -271,6 +274,7 @@ pre-commit run -a
 | <a name="input_monitor_resource_group_name"></a> [monitor\_resource\_group\_name](#input\_monitor\_resource\_group\_name) | Monitor resource group name | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | `"selc"` | no |
 | <a name="input_rbac_namespaces"></a> [rbac\_namespaces](#input\_rbac\_namespaces) | n/a | `list(string)` | <pre>[<br>  "selc"<br>]</pre> | no |
+| <a name="input_secrets_tls_certificates"></a> [secrets\_tls\_certificates](#input\_secrets\_tls\_certificates) | n/a | `set(string)` | n/a | yes |
 | <a name="input_spid_testenv_url"></a> [spid\_testenv\_url](#input\_spid\_testenv\_url) | n/a | `string` | `null` | no |
 | <a name="input_tls_cert_check_helm"></a> [tls\_cert\_check\_helm](#input\_tls\_cert\_check\_helm) | tls cert helm chart configuration | <pre>object({<br>    chart_version = string,<br>    image_name    = string,<br>    image_tag     = string<br>  })</pre> | n/a | yes |
 | <a name="input_tls_checker_https_endpoints_to_check"></a> [tls\_checker\_https\_endpoints\_to\_check](#input\_tls\_checker\_https\_endpoints\_to\_check) | List of https endpoint to check ssl certificate and his alert name | <pre>list(object({<br>    https_endpoint = string<br>    # max 53 chars, alfanumeric and '-', and lower case<br>    alert_name    = string<br>    alert_enabled = bool<br>    helm_present  = bool<br>  }))</pre> | `[]` | no |

--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -460,3 +460,18 @@ resource "kubernetes_secret" "support-secrets" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret" "secret-tls-selc-internal" {
+  for_each = var.secrets_tls_certificates
+
+  metadata {
+    name      = each.value
+    namespace = kubernetes_namespace.selc.metadata[0].name
+  }
+
+  data = {
+    "tls.crt" = data.azurerm_key_vault_certificate_data.values[each.value].hex
+    "tls.key" = data.azurerm_key_vault_certificate_data.values[each.value].key
+  }
+
+  type = "kubernetes.io/tls"
+}

--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -469,7 +469,7 @@ resource "kubernetes_secret" "secret-tls-selc-internal" {
   }
 
   data = {
-    "tls.crt" = data.azurerm_key_vault_certificate_data.values[each.value].hex
+    "tls.crt" = data.azurerm_key_vault_certificate_data.values[each.value].pem
     "tls.key" = data.azurerm_key_vault_certificate_data.values[each.value].key
   }
 

--- a/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
@@ -115,3 +115,7 @@ tls_checker_https_endpoints_to_check = [
     helm_present   = true,
   }
 ]
+
+secrets_tls_certificates = [
+  "selc-internal-dev-selfcare-pagopa-it"
+]

--- a/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
@@ -99,5 +99,5 @@ tls_checker_https_endpoints_to_check = [
 ]
 
 secrets_tls_certificates = [
-  "selc-internal-pagopa-it"
+  "selc-internal-selfcare-pagopa-it"
 ]

--- a/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
@@ -97,3 +97,7 @@ tls_checker_https_endpoints_to_check = [
     helm_present   = true,
   }
 ]
+
+secrets_tls_certificates = [
+  "selc-internal-pagopa-it"
+]

--- a/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
@@ -97,3 +97,7 @@ tls_checker_https_endpoints_to_check = [
     helm_present   = true,
   }
 ]
+
+secrets_tls_certificates = [
+  "selc-internal-uat-selfcare-pagopa-it"
+]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add a Kubernetes secret for each certificate required

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
New certificates have been released for `selc.internal.dev/uat.selfcare.pagopa.it` domain, and they need to be added to the K8S cluster as secrets

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
