### PR TITLE
[SELC-3340] Set selc A record for K8S internal DNS zone (UAT)

### DIFF
--- a/src/core/02_dns_private.tf
+++ b/src/core/02_dns_private.tf
@@ -6,6 +6,15 @@ resource "azurerm_private_dns_zone" "internal_private_dns_zone" {
   resource_group_name = azurerm_resource_group.rg_vnet.name
 }
 
+resource "azurerm_dns_a_record" "selc_internal" {
+  name                = "selc"
+  zone_name           = azurerm_private_dns_zone.internal_private_dns_zone.name
+  resource_group_name = azurerm_resource_group.rg_vnet.name
+  ttl                 = var.dns_default_ttl_sec
+  records             = [var.reverse_proxy_ip]
+  tags                = var.tags
+}
+
 #
 # DNS private Link
 #

--- a/src/core/02_dns_public.tf
+++ b/src/core/02_dns_public.tf
@@ -228,12 +228,3 @@ resource "azurerm_dns_cname_record" "dkim-aws-ses-selfcare-pagopa-it" {
   record              = each.value.value
   tags                = var.tags
 }
-
-resource "azurerm_dns_a_record" "selc_internal" {
-  name                = "selc.internal"
-  zone_name           = azurerm_dns_zone.selfcare_public[0].name
-  resource_group_name = azurerm_resource_group.rg_vnet.name
-  ttl                 = var.dns_default_ttl_sec
-  records             = [var.reverse_proxy_ip]
-  tags                = var.tags
-}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Set A record to resolve internal DNS to K8S load balancer IP

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Prepration for cluster upgrade

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
