### PR TITLE
[SELC-3340] Update roles on AZOPS service account

### DIFF
--- a/src/k8s/01_serviceaccounts.tf
+++ b/src/k8s/01_serviceaccounts.tf
@@ -13,8 +13,8 @@ resource "kubernetes_cluster_role" "cluster_deployer" {
 
   # required to run helm
   rule {
-    api_groups = ["", "extensions", "apps"]
-    resources  = ["deployments", "replicasets", "horizontalpodautoscalers", "services", "pods", "jobs", "scheduledjobs", "crontabs", "configmaps", "secrets"]
+    api_groups = ["", "extensions", "apps", "policy"]
+    resources  = ["deployments", "replicasets", "horizontalpodautoscalers", "services", "pods", "jobs", "scheduledjobs", "crontabs", "configmaps", "secrets", "poddisruptionbudgets"]
     verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Update service account used by Azure DevOps with god role over `poddisruptionbudgets` in `policy` api group

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Azure DevOps should be able to set PDB policies

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [X] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
