### PR TITLE
[SELC-3407] Feat: added billing_url and billing_audience in env

### DIFF
--- a/src/k8s/99_variables.tf
+++ b/src/k8s/99_variables.tf
@@ -100,6 +100,14 @@ variable "jwt_token_exchange_duration" {
   default = "PT15S"
 }
 
+variable "token_exchange_billing_audience"{
+  type    = string
+}
+
+variable "token_exchange_billing_url"{
+  type    = string
+}
+
 # configs/secrets
 variable "jwt_audience" {
   type = string

--- a/src/k8s/99_variables.tf
+++ b/src/k8s/99_variables.tf
@@ -100,12 +100,12 @@ variable "jwt_token_exchange_duration" {
   default = "PT15S"
 }
 
-variable "token_exchange_billing_audience"{
-  type    = string
+variable "token_exchange_billing_audience" {
+  type = string
 }
 
-variable "token_exchange_billing_url"{
-  type    = string
+variable "token_exchange_billing_url" {
+  type = string
 }
 
 # configs/secrets

--- a/src/k8s/README.md
+++ b/src/k8s/README.md
@@ -279,6 +279,8 @@ pre-commit run -a
 | <a name="input_spid_testenv_url"></a> [spid\_testenv\_url](#input\_spid\_testenv\_url) | n/a | `string` | `null` | no |
 | <a name="input_tls_cert_check_helm"></a> [tls\_cert\_check\_helm](#input\_tls\_cert\_check\_helm) | tls cert helm chart configuration | <pre>object({<br>    chart_version = string,<br>    image_name    = string,<br>    image_tag     = string<br>  })</pre> | n/a | yes |
 | <a name="input_tls_checker_https_endpoints_to_check"></a> [tls\_checker\_https\_endpoints\_to\_check](#input\_tls\_checker\_https\_endpoints\_to\_check) | List of https endpoint to check ssl certificate and his alert name | <pre>list(object({<br>    https_endpoint = string<br>    # max 53 chars, alfanumeric and '-', and lower case<br>    alert_name    = string<br>    alert_enabled = bool<br>    helm_present  = bool<br>  }))</pre> | `[]` | no |
+| <a name="input_token_exchange_billing_audience"></a> [token\_exchange\_billing\_audience](#input\_token\_exchange\_billing\_audience) | n/a | `string` | n/a | yes |
+| <a name="input_token_exchange_billing_url"></a> [token\_exchange\_billing\_url](#input\_token\_exchange\_billing\_url) | n/a | `string` | n/a | yes |
 | <a name="input_token_expiration_minutes"></a> [token\_expiration\_minutes](#input\_token\_expiration\_minutes) | n/a | `number` | `540` | no |
 
 ## Outputs

--- a/src/k8s/selc_configmaps.tf
+++ b/src/k8s/selc_configmaps.tf
@@ -43,10 +43,12 @@ resource "kubernetes_config_map" "jwt-exchange" {
   }
 
   data = {
-    JWT_TOKEN_EXCHANGE_DURATION   = var.jwt_token_exchange_duration
-    JWT_TOKEN_EXCHANGE_KID        = module.key_vault_secrets_query.values["jwt-exchange-kid"].value
-    JWT_TOKEN_EXCHANGE_PUBLIC_KEY = module.key_vault_secrets_query.values["jwt-exchange-public-key"].value
-    WELL_KNOWN_URL                = format("%s/.well-known/jwks.json", var.cdn_storage_url)
+    JWT_TOKEN_EXCHANGE_DURATION     = var.jwt_token_exchange_duration
+    JWT_TOKEN_EXCHANGE_KID          = module.key_vault_secrets_query.values["jwt-exchange-kid"].value
+    JWT_TOKEN_EXCHANGE_PUBLIC_KEY   = module.key_vault_secrets_query.values["jwt-exchange-public-key"].value
+    WELL_KNOWN_URL                  = format("%s/.well-known/jwks.json", var.cdn_storage_url)
+    TOKEN_EXCHANGE_BILLING_URL      = var.token_exchange_billing_url
+    TOKEN_EXCHANGE_BILLING_AUDIENCE = var.token_exchange_billing_audience
   }
 }
 

--- a/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
@@ -24,7 +24,7 @@ jwt_token_exchange_duration = "PT15M"
 
 # Billing Token Exchange audience and url
 token_exchange_billing_audience = "api.dev.selfcare.pagopa.it"
-token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it/#selfcareToken=<IdentityToken>"
+token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
 
 # session jwt audience
 jwt_audience = "api.dev.selfcare.pagopa.it"

--- a/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
@@ -22,6 +22,10 @@ api-version_uservice-party-registry-proxy = "v1"
 # jwt exchange duration
 jwt_token_exchange_duration = "PT15M"
 
+# Billing Token Exchange audience and url
+token_exchange_billing_audience = "api.dev.selfcare.pagopa.it"
+token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it/#selfcareToken=<IdentityToken>"
+
 # session jwt audience
 jwt_audience = "api.dev.selfcare.pagopa.it"
 

--- a/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
@@ -24,7 +24,7 @@ jwt_token_exchange_duration = "PT15M"
 
 # Billing Token Exchange audience and url
 token_exchange_billing_audience = "api.dev.selfcare.pagopa.it"
-token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
+token_exchange_billing_url      = "http://dev.portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
 
 # session jwt audience
 jwt_audience = "api.dev.selfcare.pagopa.it"

--- a/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
@@ -20,7 +20,7 @@ api-version_uservice-party-registry-proxy = "v1"
 
 # Billing Token Exchange audience and url
 token_exchange_billing_audience = "api.selfcare.pagopa.it"
-token_exchange_billing_url = "http://portalefatturazione.pagopa.it/#selfcareToken=<IdentityToken>"
+token_exchange_billing_url = "http://portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
 
 # session jwt audience
 jwt_audience = "api.selfcare.pagopa.it"

--- a/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
@@ -18,6 +18,10 @@ api-version_uservice-party-management     = "0.1"
 api-version_uservice-party-process        = "0.1"
 api-version_uservice-party-registry-proxy = "v1"
 
+# Billing Token Exchange audience and url
+token_exchange_billing_audience = "api.selfcare.pagopa.it"
+token_exchange_billing_url = "http://portalefatturazione.pagopa.it/#selfcareToken=<IdentityToken>"
+
 # session jwt audience
 jwt_audience = "api.selfcare.pagopa.it"
 

--- a/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
@@ -20,7 +20,7 @@ api-version_uservice-party-registry-proxy = "v1"
 
 # Billing Token Exchange audience and url
 token_exchange_billing_audience = "api.selfcare.pagopa.it"
-token_exchange_billing_url = "http://portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
+token_exchange_billing_url      = "http://portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
 
 # session jwt audience
 jwt_audience = "api.selfcare.pagopa.it"

--- a/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
@@ -19,6 +19,10 @@ api-version_uservice-party-management     = "0.1"
 api-version_uservice-party-process        = "0.1"
 api-version_uservice-party-registry-proxy = "v1"
 
+# Billing Token Exchange audience and url
+token_exchange_billing_audience = "api.uat.selfcare.pagopa.it"
+token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it/#selfcareToken=<IdentityToken>"
+
 # session jwt audience
 jwt_audience = "api.uat.selfcare.pagopa.it"
 

--- a/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
@@ -21,7 +21,7 @@ api-version_uservice-party-registry-proxy = "v1"
 
 # Billing Token Exchange audience and url
 token_exchange_billing_audience = "api.uat.selfcare.pagopa.it"
-token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it/#selfcareToken=<IdentityToken>"
+token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
 
 # session jwt audience
 jwt_audience = "api.uat.selfcare.pagopa.it"

--- a/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
@@ -21,7 +21,7 @@ api-version_uservice-party-registry-proxy = "v1"
 
 # Billing Token Exchange audience and url
 token_exchange_billing_audience = "api.uat.selfcare.pagopa.it"
-token_exchange_billing_url = "http://dev.portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
+token_exchange_billing_url      = "http://dev.portalefatturazione.pagopa.it?selfcareToken=<IdentityToken>"
 
 # session jwt audience
 jwt_audience = "api.uat.selfcare.pagopa.it"


### PR DESCRIPTION
**List of changes**
- added billing_url and billing_audience in env

**Motivation and context**
To access new Billing BO, a new API is required which builds a jwt that can be used for this portal and which contains the list of invoiceable products related to logged user, so for this API we need to have 2 new env variables

**Type of changes**
-  Add new var in jwt_exchange config map

**Env to apply**
- [x]  DEV
- [x]  UAT
- [x]  PROD

**Does this introduce a change to production resources with possible user impact?**
- [ ]  Yes, users may be impacted applying this change
- [x]  No

**Does this introduce an unwanted change on infrastructure? Check terraform plan execution result**
- [ ]  Yes
- [x]  No
