### PR TITLE
[SELC-3450] feat: added api getUserById into support service api

### DIFF
--- a/src/core/api/selfcare_support_service/v1/getUserInfoUsingGet_op_policy.xml.tpl
+++ b/src/core/api/selfcare_support_service/v1/getUserInfoUsingGet_op_policy.xml.tpl
@@ -31,9 +31,6 @@
         <set-header name="Authorization" exists-action="override">
             <value>@((string)context.Variables["jwt"])</value>
         </set-header>
-        <set-query-parameter name="productId" exists-action="override">
-              <value>@((string)context.Variables["productId"])</value>
-         </set-query-parameter>
         <set-backend-service base-url="${MS_CORE_BACKEND_BASE_URL}" />
     </inbound>
     <backend>

--- a/src/core/api/selfcare_support_service/v1/getUserInfoUsingGet_op_policy.xml.tpl
+++ b/src/core/api/selfcare_support_service/v1/getUserInfoUsingGet_op_policy.xml.tpl
@@ -1,0 +1,45 @@
+<policies>
+    <inbound>
+        <base/>
+        <set-variable name="jwt" value="@{
+            // 1) Construct the Base64Url-encoded header
+            var header = new { typ = "JWT", alg = "RS256", kid = "${KID}" };
+            var jwtHeaderBase64UrlEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(header))).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+            // As the header is a constant, you may use this equivalent Base64Url-encoded string instead to save the repetitive computation above.
+            // var jwtHeaderBase64UrlEncoded = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9";
+
+            // 2) Construct the Base64Url-encoded payload
+            var exp = new DateTimeOffset(DateTime.Now.AddMinutes(30)).ToUnixTimeSeconds();  // sets the expiration of the token to be 30 seconds from now
+            var uid = "m2m";
+            var aud = "${API_DOMAIN}";
+            var iss = "SPID";
+            var payload = new { exp, uid, aud, iss };
+            var jwtPayloadBase64UrlEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(payload))).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+
+            // 3) Construct the Base64Url-encoded signature
+            using (RSA rsa = context.Deployment.Certificates["${JWT_CERTIFICATE_THUMBPRINT}"].GetRSAPrivateKey())
+            {
+            byte[] data2sign = Encoding.UTF8.GetBytes($"{jwtHeaderBase64UrlEncoded}.{jwtPayloadBase64UrlEncoded}");
+            var signature = rsa.SignData(data2sign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);;
+            var jwtSignatureBase64UrlEncoded = Convert.ToBase64String(signature).Replace("/", "_").Replace("+", "-"). Replace("=", "");
+
+            // 4) Return the HMAC SHA256-signed JWT as the value for the Authorization header
+            return $"Bearer {jwtHeaderBase64UrlEncoded}.{jwtPayloadBase64UrlEncoded}.{jwtSignatureBase64UrlEncoded}";
+            }
+
+            }"/>
+        <set-header name="Authorization" exists-action="override">
+            <value>@((string)context.Variables["jwt"])</value>
+        </set-header>
+        <set-query-parameter name="productId" exists-action="override">
+              <value>@((string)context.Variables["productId"])</value>
+         </set-query-parameter>
+        <set-backend-service base-url="${MS_CORE_BACKEND_BASE_URL}" />
+    </inbound>
+    <backend>
+        <base/>
+    </backend>
+    <on-error>
+        <base/>
+    </on-error>
+</policies>

--- a/src/core/api/selfcare_support_service/v1/open-api.yml.tpl
+++ b/src/core/api/selfcare_support_service/v1/open-api.yml.tpl
@@ -189,6 +189,50 @@ paths:
       security:
         - bearerAuth:
             - global
+  '/users/{id}':
+    get:
+      tags:
+        - users
+      summary: getUserById
+      description: Get user by Id
+      operationId: getUserInfoUsingGET
+      parameters:
+        - name: id
+          in: path
+          description: User's unique identifier
+          required: true
+          style: simple
+          schema:
+            type: string
+        - name: institutionId
+          in: query
+          description: The internal identifier of the institution
+          required: false
+          style: form
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+      security:
+        - bearerAuth:
+            - global
   '/delegations':
     get:
       tags:
@@ -1251,6 +1295,20 @@ components:
         updatedAt:
           type: string
           format: date-time
+    UserResponse:
+      title: UserResponse
+      type: object
+      properties:
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        surname:
+          type: string
+        taxCode:
+          type: string
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -883,6 +883,15 @@ module "apim_selfcare_support_service_v1" {
       })
     },
     {
+      operation_id = "getUserInfoUsingGET"
+      xml_content = templatefile("./api/selfcare_support_service/v1/getUserInfoUsingGet_op_policy.xml.tpl", {
+        MS_CORE_BACKEND_BASE_URL   = "http://${var.private_dns_name}/ms-core/v1/"
+        API_DOMAIN                 = local.api_domain
+        KID                        = module.jwt.jwt_kid
+        JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
+      })
+    },
+    {
       operation_id = "getInstitutionUsersUsingGET"
       xml_content = templatefile("./api/selfcare_support_service/v1/getInstitutionUsersUsingGET_op_policy.xml.tpl", {
         MS_CORE_BACKEND_BASE_URL   = "http://${var.private_dns_name}/ms-core/v1/"


### PR DESCRIPTION
### List of changes

Added api getUserById into support service api

### Motivation and context

This API has been added to allow support service to retrieve user's info by internal identifier.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No
