### PR TITLE
[SELC-3490] feat: added github action to autogenerate open api for support set of API

### DIFF
--- a/.github/workflows/merge_open_api.yml
+++ b/.github/workflows/merge_open_api.yml
@@ -1,0 +1,49 @@
+name: Generate Support Open Api
+on:
+  pull_request:
+    branches:
+      - develop
+      -feature/SELC-3490
+    types: [ opened, reopened ]
+  workflow_dispatch: #allow to run github action manually
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    #if: github.event.pull_request.merged == true
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Check out ms-core
+      uses: actions/checkout@v3
+      with:
+          name: pagopa/selfcare-ms-core
+          ref: feature/SELC-3460
+          path: ms-core
+          token: ${{ github.token }}
+    - name: Check out external-api 
+      uses: actions/checkout@v3
+      with:
+          name: pagopa/selfcare-external-api-backend
+          ref: feature/SELC-3460
+          path: external-api
+          token: ${{ github.token }}
+    - name: Generate merged open api
+      run: |
+        cd src/core/api/selfcare_support_service/v1
+        npm i openapi-merge-cli
+        npx openapi-merge-cli
+    - name: Commit api-docs
+      run: |
+          git ls-files ./app** | grep 'api-docs*' | xargs git add
+          git config --global user.email "selfcare-github@pagopa.it"
+          git config --global user.name "selfcare-github-bot"
+          git commit -m "Generated Support Swagger documentation" || exit 0
+          git push origin ${{ github.ref_name}}

--- a/.github/workflows/merge_open_api.yml
+++ b/.github/workflows/merge_open_api.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - develop
-      -feature/SELC-3490
+      - feature/SELC-3490
     types: [ opened, reopened ]
   workflow_dispatch: #allow to run github action manually
 permissions:

--- a/src/core/api/selfcare_support_service/v1/openapi-merge.json
+++ b/src/core/api/selfcare_support_service/v1/openapi-merge.json
@@ -1,0 +1,17 @@
+{
+    "inputs": [
+      {
+        "inputFile": "./ms-core/app/src/main/resources/swagger/api-docs.json",
+        "operationSelection": {
+          "includeTags": ["support"]
+        }
+      },
+      {
+        "inputFile": "./external-api/app/src/main/resources/swagger/api-docs.json",
+        "operationSelection": {
+          "includeTags": ["support"]
+        }
+      }
+    ], 
+    "output": "./output.swagger.json"
+  }


### PR DESCRIPTION
### List of changes

Added github action to autogenerate open api for support set of API

### Motivation and context

In order to avoid manual update of open api for each set of service, it has been added a github action to automatically update the file. For this purpose, into the action, there is a specific step that merge docs from different repos.

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No