### PR TITLE
[SELC-3487] Feat: add configMap and secret for anac-ftp

### DIFF
--- a/src/domains/pnpg-app/00_secrets.tf
+++ b/src/domains/pnpg-app/00_secrets.tf
@@ -53,6 +53,8 @@ module "key_vault_secrets_query" {
     "user-registry-api-key",
     "user-registry-api-key",
     "web-storage-connection-string",
-    "alert-pnpg-http-status-slack"
+    "alert-pnpg-http-status-slack",
+    "anac-ftp-password",
+    "anac-ftp-known-host"
   ]
 }

--- a/src/domains/pnpg-app/10_selc_configmaps.tf
+++ b/src/domains/pnpg-app/10_selc_configmaps.tf
@@ -255,3 +255,12 @@ resource "kubernetes_config_map" "national-registries-service" {
   data = var.configmaps_national_registries
 
 }
+
+resource "kubernetes_config_map" "anac-ftp" {
+  metadata {
+    name      = "anac-ftp"
+    namespace = var.domain
+  }
+
+  data = var.anac-ftp
+}

--- a/src/domains/pnpg-app/10_selc_secrets.tf
+++ b/src/domains/pnpg-app/10_selc_secrets.tf
@@ -362,3 +362,17 @@ resource "kubernetes_secret" "support-secrets" {
 
   type = "Opaque"
 }
+
+resource "kubernetes_secret" "anac-ftp-secret" {
+  metadata {
+    name      = "anac-ftp-secret"
+    namespace = kubernetes_namespace.selc.metadata[0].name
+  }
+
+  data = {
+    ANAC_FTP_PASSWORD = module.key_vault_secrets_query.values["anac-ftp-password"].value
+    ANAC_FTP_KNOWN_HOST = module.key_vault_secrets_query.values["anac-ftp-known-host"].value
+  }
+
+  type = "Opaque"
+}

--- a/src/domains/pnpg-app/99_variables.tf
+++ b/src/domains/pnpg-app/99_variables.tf
@@ -249,6 +249,10 @@ variable "geo-taxonomies" {
   type = map(string)
 }
 
+variable "anac-ftp" {
+  type = map(string)
+}
+
 variable "api_gateway_url" {
   type = string
 }

--- a/src/domains/pnpg-app/env/dev/terraform.tfvars
+++ b/src/domains/pnpg-app/env/dev/terraform.tfvars
@@ -128,6 +128,12 @@ geo-taxonomies = {
   GEO_TAXONOMIES_URL = "https://api-pnpg.dev.selfcare.pagopa.it/external"
 }
 
+anac-ftp = {
+  ANAC_FTP_IP = "93.43.119.85"
+  ANAC_FTP_USER = "PagoPA_user"
+  ANAC_FTP_DIRECTORY = "/mnt/RegistroGestoriPiattaforme/Collaudo/"
+}
+
 
 terraform_remote_state_core = {
   resource_group_name  = "terraform-state-rg"

--- a/src/domains/pnpg-app/env/prod/terraform.tfvars
+++ b/src/domains/pnpg-app/env/prod/terraform.tfvars
@@ -127,6 +127,12 @@ geo-taxonomies = {
   GEO_TAXONOMIES_URL = "https://api-pnpg.selfcare.pagopa.it/external"
 }
 
+anac-ftp = {
+  ANAC_FTP_IP = "93.43.119.85"
+  ANAC_FTP_USER = "PagoPA_user"
+  ANAC_FTP_DIRECTORY = "/mnt/RegistroGestoriPiattaforme/Collaudo/"
+}
+
 
 terraform_remote_state_core = {
   resource_group_name  = "terraform-state-rg"

--- a/src/domains/pnpg-app/env/uat/terraform.tfvars
+++ b/src/domains/pnpg-app/env/uat/terraform.tfvars
@@ -128,6 +128,12 @@ geo-taxonomies = {
   GEO_TAXONOMIES_URL = "https://api-pnpg.uat.selfcare.pagopa.it/external"
 }
 
+anac-ftp = {
+  ANAC_FTP_IP = "93.43.119.85"
+  ANAC_FTP_USER = "PagoPA_user"
+  ANAC_FTP_DIRECTORY = "/mnt/RegistroGestoriPiattaforme/Collaudo/"
+}
+
 terraform_remote_state_core = {
   resource_group_name  = "terraform-state-rg"
   storage_account_name = "tfinfuatselfcare"

--- a/src/k8s/00_secrets.tf
+++ b/src/k8s/00_secrets.tf
@@ -63,7 +63,8 @@ module "key_vault_secrets_query" {
     "zendesk-support-api-key",
     "prod-fd-client-id",
     "prod-fd-client-secret",
-    "prod-fd-grant-type"
-
+    "prod-fd-grant-type",
+    "anac-ftp-password",
+    "anac-ftp-known-host"
   ]
 }

--- a/src/k8s/99_variables.tf
+++ b/src/k8s/99_variables.tf
@@ -142,6 +142,10 @@ variable "geo-taxonomies" {
   type = map(string)
 }
 
+variable "anac-ftp" {
+  type = map(string)
+}
+
 variable "external-interceptor-url" {
   type = map(string)
 }

--- a/src/k8s/selc_configmaps.tf
+++ b/src/k8s/selc_configmaps.tf
@@ -285,3 +285,12 @@ resource "kubernetes_config_map" "geo-taxonomies" {
 
   data = var.geo-taxonomies
 }
+
+resource "kubernetes_config_map" "anac-ftp" {
+  metadata {
+    name      = "anac-ftp"
+    namespace = kubernetes_namespace.selc.metadata[0].name
+  }
+
+  data = var.anac-ftp
+}

--- a/src/k8s/selc_secrets.tf
+++ b/src/k8s/selc_secrets.tf
@@ -475,3 +475,17 @@ resource "kubernetes_secret" "secret-tls-selc-internal" {
 
   type = "kubernetes.io/tls"
 }
+
+resource "kubernetes_secret" "anac-ftp-secret" {
+  metadata {
+    name      = "anac-ftp-secret"
+    namespace = kubernetes_namespace.selc.metadata[0].name
+  }
+
+  data = {
+    ANAC_FTP_PASSWORD = module.key_vault_secrets_query.values["anac-ftp-password"].value
+    ANAC_FTP_KNOWN_HOST = module.key_vault_secrets_query.values["anac-ftp-known-host"].value
+  }
+
+  type = "Opaque"
+}

--- a/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-SelfCare/terraform.tfvars
@@ -81,6 +81,12 @@ geo-taxonomies = {
   GEO_TAXONOMIES_URL = "https://api.pdnd.pagopa.it/geo-tax"
 }
 
+anac-ftp = {
+  ANAC_FTP_IP = "93.43.119.85"
+  ANAC_FTP_USER = "PagoPA_user"
+  ANAC_FTP_DIRECTORY = "/mnt/RegistroGestoriPiattaforme/Collaudo/"
+}
+
 external-interceptor-url = {
   PROD_FD_URL = "https://fid00001fe.siachain.sv.sia.eu:30008"
 }

--- a/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-SelfCare/terraform.tfvars
@@ -78,6 +78,12 @@ geo-taxonomies = {
   GEO_TAXONOMIES_URL = "https://api.dev.selfcare.pagopa.it/external"
 }
 
+anac-ftp = {
+  ANAC_FTP_IP = "93.43.119.85"
+  ANAC_FTP_USER = "PagoPA_user"
+  ANAC_FTP_DIRECTORY = "/mnt/RegistroGestoriPiattaforme/Collaudo/"
+}
+
 external-interceptor-url = {
   PROD_FD_URL = "https://portale.fideiussionidigitali.it"
 }

--- a/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-SelfCare/terraform.tfvars
@@ -79,6 +79,12 @@ geo-taxonomies = {
   GEO_TAXONOMIES_URL = "https://api.dev.selfcare.pagopa.it/external"
 }
 
+anac-ftp = {
+  ANAC_FTP_IP = "93.43.119.85"
+  ANAC_FTP_USER = "PagoPA_user"
+  ANAC_FTP_DIRECTORY = "/mnt/RegistroGestoriPiattaforme/Collaudo/"
+}
+
 external-interceptor-url = {
   PROD_FD_URL = "https://fid00001fe.siachain.ti.sia.eu:30008"
 }


### PR DESCRIPTION
**List of changes**
added configMap and secret for anac-ftp

**Motivation and context**
In order to avoid manual update of anac csv file, we have to retrieve it from ftp. We need env variables to estabilish this connection to sftp server.

**Type of changes**
 Add new configMap anc secrets

**Env to apply**
- [x] DEV
- [x]  UAT
- [x]  PROD

**Does this introduce a change to production resources with possible user impact?**
- [ ]  Yes, users may be impacted applying this change
- [x]  No

**Does this introduce an unwanted change on infrastructure? Check terraform plan execution result**
- [ ]  Yes
- [ ]  No