### PR TITLE
[SELC-3583] Update AKS UAT config to match real infra after AKS upgrade

### DIFF
--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -80,10 +80,10 @@ redis_version  = 6
 
 # aks
 aks_alerts_enabled                  = false
-aks_kubernetes_version              = "1.25.11"
+aks_kubernetes_version              = "1.27.7"
 aks_system_node_pool_os_disk_type   = "Managed"
 aks_system_node_pool_node_count_min = 1
-aks_system_node_pool_node_count_max = 1
+aks_system_node_pool_node_count_max = 2
 
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
 reverse_proxy_ip = "10.1.1.250"
@@ -95,7 +95,7 @@ system_node_pool_enable_host_encryption           = false
 
 aks_user_node_pool_enabled        = true
 aks_user_node_pool_os_disk_type   = "Managed"
-aks_user_node_pool_node_count_min = 3
+aks_user_node_pool_node_count_min = 2
 aks_user_node_pool_node_count_max = 4
 user_node_pool_node_labels = {
   "node_type" = "user"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
AKS version upgrade
Autoscaler enabled

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
AKS has been upgraded, these changes reflect changes made by Az portal

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
