### PR TITLE
[SELC-3307] feat: modify url key  in API External v2

### DIFF
--- a/src/core/api/ms_external_api/v2/getInstitution_op_policy.xml.tpl
+++ b/src/core/api/ms_external_api/v2/getInstitution_op_policy.xml.tpl
@@ -55,7 +55,7 @@
             <when condition="@(context.Response.StatusCode == 200)">
                 <set-body>@{
                     JObject response = context.Response.Body.As<JObject>();
-                    response.Add("logo", new JValue(new Uri("${CDN_STORAGE_URL}/institutions/" + response.GetValue("id") + "/logo.png")));
+                    response.Add("logo", new JValue(new Uri("${LOGO_URL}/institutions/" + response.GetValue("id") + "/logo.png")));
                     return response.ToString();
                     }</set-body>
             </when>

--- a/src/core/api/ms_external_api/v2/getInstitutions_op_policy.xml.tpl
+++ b/src/core/api/ms_external_api/v2/getInstitutions_op_policy.xml.tpl
@@ -63,7 +63,7 @@
                 <set-body>@{
                     JArray response = context.Response.Body.As<JArray>();
                     foreach(JObject item in response.Children()) {
-                    item.Add("logo", new JValue(new Uri("${CDN_STORAGE_URL}/institutions/" + item.GetValue("id") + "/logo.png")));
+                    item.Add("logo", new JValue(new Uri("${LOGO_URL}/institutions/" + item.GetValue("id") + "/logo.png")));
                     }
                     return response.ToString();
                     }</set-body>

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -20,9 +20,9 @@ resource "azurerm_resource_group" "rg_api" {
 locals {
   apim_cert_name_proxy_endpoint = format("%s-proxy-endpoint-cert", local.project)
 
-  api_domain    = format("api.%s.%s", var.dns_zone_prefix, var.external_domain)
+  api_domain      = format("api.%s.%s", var.dns_zone_prefix, var.external_domain)
   logo_api_domain = format("%s.%s", var.dns_zone_prefix, var.external_domain)
-  apim_base_url = "${azurerm_api_management_custom_domain.api_custom_domain.gateway[0].host_name}/external"
+  apim_base_url   = "${azurerm_api_management_custom_domain.api_custom_domain.gateway[0].host_name}/external"
 }
 
 resource "azurerm_api_management_custom_domain" "api_custom_domain" {
@@ -555,7 +555,7 @@ module "apim_external_api_ms_v2" {
     {
       operation_id = "getInstitutionsUsingGET"
       xml_content = templatefile("./api/ms_external_api/v2/getInstitutions_op_policy.xml.tpl", {
-        LOGO_URL            = "https://${local.logo_api_domain}"
+        LOGO_URL                   = "https://${local.logo_api_domain}"
         API_DOMAIN                 = local.api_domain
         KID                        = module.jwt.jwt_kid
         JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
@@ -612,7 +612,7 @@ module "apim_external_api_ms_v2" {
     {
       operation_id = "getInstitution"
       xml_content = templatefile("./api/ms_external_api/v2/getInstitution_op_policy.xml.tpl", {
-        LOGO_URL                = "https://${local.logo_api_domain}"
+        LOGO_URL                       = "https://${local.logo_api_domain}"
         PARTY_PROCESS_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
         API_DOMAIN                     = local.api_domain
         KID                            = module.jwt.jwt_kid

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -555,7 +555,7 @@ module "apim_external_api_ms_v2" {
     {
       operation_id = "getInstitutionsUsingGET"
       xml_content = templatefile("./api/ms_external_api/v2/getInstitutions_op_policy.xml.tpl", {
-        CDN_STORAGE_URL            = "https://${local.logo_api_domain}"
+        LOGO_URL            = "https://${local.logo_api_domain}"
         API_DOMAIN                 = local.api_domain
         KID                        = module.jwt.jwt_kid
         JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
@@ -612,7 +612,7 @@ module "apim_external_api_ms_v2" {
     {
       operation_id = "getInstitution"
       xml_content = templatefile("./api/ms_external_api/v2/getInstitution_op_policy.xml.tpl", {
-        CDN_STORAGE_URL                = "https://${local.logo_api_domain}"
+        LOGO_URL                = "https://${local.logo_api_domain}"
         PARTY_PROCESS_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
         API_DOMAIN                     = local.api_domain
         KID                            = module.jwt.jwt_kid

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -21,6 +21,7 @@ locals {
   apim_cert_name_proxy_endpoint = format("%s-proxy-endpoint-cert", local.project)
 
   api_domain    = format("api.%s.%s", var.dns_zone_prefix, var.external_domain)
+  logo_api_domain = format("%s.%s", var.dns_zone_prefix, var.external_domain)
   apim_base_url = "${azurerm_api_management_custom_domain.api_custom_domain.gateway[0].host_name}/external"
 }
 
@@ -554,7 +555,7 @@ module "apim_external_api_ms_v2" {
     {
       operation_id = "getInstitutionsUsingGET"
       xml_content = templatefile("./api/ms_external_api/v2/getInstitutions_op_policy.xml.tpl", {
-        CDN_STORAGE_URL            = "https://${module.checkout_cdn.storage_primary_web_host}"
+        CDN_STORAGE_URL            = "https://${local.logo_api_domain}"
         API_DOMAIN                 = local.api_domain
         KID                        = module.jwt.jwt_kid
         JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
@@ -611,7 +612,7 @@ module "apim_external_api_ms_v2" {
     {
       operation_id = "getInstitution"
       xml_content = templatefile("./api/ms_external_api/v2/getInstitution_op_policy.xml.tpl", {
-        CDN_STORAGE_URL                = "https://${module.checkout_cdn.storage_primary_web_host}"
+        CDN_STORAGE_URL                = "https://${local.logo_api_domain}"
         PARTY_PROCESS_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
         API_DOMAIN                     = local.api_domain
         KID                            = module.jwt.jwt_kid


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- modify key LOGO_URL and its value in API External v2
<!--- Describe your changes in detail -->

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
The URL previously used (the CDND storage url) is not externally accessible. Being the API exposed externally, the URL was changed with another one externally accessible.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
