### PR TITLE
[EC-109] Add explicit TF init to code review pipeline

### DIFF
--- a/.github/workflows/call_code_review.yml
+++ b/.github/workflows/call_code_review.yml
@@ -15,6 +15,7 @@ env:
   ENV_NAME: "${{ inputs.environment != null && inputs.environment || (github.base_ref == 'main' && 'prod' || (github.base_ref == 'develop' && 'uat' || 'dev')) }}"
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_CI }}
   ARM_USE_OIDC: true
   ARM_USE_AZUREAD: true
   ARM_STORAGE_USE_AZUREAD: true

--- a/.github/workflows/call_code_review.yml
+++ b/.github/workflows/call_code_review.yml
@@ -61,6 +61,11 @@ jobs:
           terraform_version: ${{ steps.set-terraform-version.outputs.terraform_version }}
           terraform_wrapper: true
 
+      - name: Terraform Init
+        working-directory: ${{ inputs.dir }}
+        run: |
+          bash ./terraform.sh init ${{ steps.env_read.outputs.environment }}
+
       - name: Terraform Plan
         working-directory: ${{ inputs.dir }}
         continue-on-error: true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add explicit TF init step to pr pipelines

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
For some reason, selfcare's terraform.sh file doesn't perform an `init` when the `plan` command is given

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
