### PR TITLE
[SELC-4015] feat: remove autoApprovalOnboarding api from internal apim

### DIFF
--- a/src/core/api/ms_internal_api/v1/open-api.yml.tpl
+++ b/src/core/api/ms_internal_api/v1/open-api.yml.tpl
@@ -217,75 +217,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-  '/onboarding/{externalInstitutionId}/products/{productId}':
-      post:
-        tags:
-          - onboarding
-        summary: autoApprovalOnboarding
-        description: The service allows the onboarding of institutions with auto approval
-        operationId: autoApprovalOnboardingUsingPOST
-        parameters:
-          - name: x-selfcare-uid
-            in: header
-            description: Logged user's unique identifier
-            required: true
-            schema:
-              type: string
-          - name: externalInstitutionId
-            in: path
-            description: Institution's unique external identifier
-            required: true
-            style: simple
-            schema:
-              type: string
-          - name: productId
-            in: path
-            description: Product's unique identifier
-            required: true
-            style: simple
-            schema:
-              type: string
-        requestBody:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OnboardingDto'
-        responses:
-          '201':
-            description: Created
-          '400':
-            description: Bad Request
-            content:
-              application/problem+json:
-                schema:
-                  $ref: '#/components/schemas/Problem'
-          '401':
-            description: Unauthorized
-            content:
-              application/problem+json:
-                schema:
-                  $ref: '#/components/schemas/Problem'
-          '403':
-                    description: Forbidden
-                    content:
-                      application/problem+json:
-                        schema:
-                          $ref: '#/components/schemas/Problem'
-          '409':
-                  description: Conflict
-                  content:
-                      application/problem+json:
-                        schema:
-                          $ref: '#/components/schemas/Problem'
-          '500':
-            description: Internal Server Error
-            content:
-              application/problem+json:
-                schema:
-                  $ref: '#/components/schemas/Problem'
-        security:
-          - bearerAuth:
-              - global
   '/products/{productId}':
       get:
         tags:
@@ -844,55 +775,6 @@ components:
         filePath:
           type: string
           description: Institution's contract file path
-    OnboardingDto:
-      title: OnboardingDto
-      required:
-        - billingData
-        - geographicTaxonomies
-        - institutionType
-        - users
-      type: object
-      properties:
-        assistanceContacts:
-          description: Institution's assistance contacts
-          $ref: '#/components/schemas/AssistanceContactsDto'
-        billingData:
-          description: Institution's billing information
-          $ref: '#/components/schemas/BillingDataDto'
-        companyInformations:
-          description: GPS, SCP, PT optional data
-          $ref: '#/components/schemas/CompanyInformationsDto'
-        geographicTaxonomies:
-          type: array
-          description: Institution's geographic taxonomy
-          items:
-            $ref: '#/components/schemas/GeographicTaxonomyDto'
-        institutionType:
-          type: string
-          description: Institution's type
-          enum:
-            - GSP
-            - PA
-            - PSP
-            - PT
-            - SCP
-            - SA
-            - REC
-            - CON
-        origin:
-          type: string
-          description: Institution data origin
-        pricingPlan:
-          type: string
-          description: Product's pricing plan
-        pspData:
-          description: Payment Service Provider (PSP) specific data
-          $ref: '#/components/schemas/PspDataDto'
-        users:
-          type: array
-          description: List of onboarding users
-          items:
-            $ref: '#/components/schemas/UserDto'
     PspDataDto:
       title: PspDataDto
       required:

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -818,7 +818,7 @@ module "apim_internal_api_ms_v1" {
     {
       operation_id = "completeOnboardingTokenConsume"
       xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
-        MS_ONBOARDING_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
+        MS_CORE_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
         }
       )
     }

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -776,10 +776,6 @@ module "apim_internal_api_ms_v1" {
       })
     },
     {
-      operation_id = "autoApprovalOnboardingUsingPOST"
-      xml_content  = file("./api/jwt_auth_op_policy.xml")
-    },
-    {
       operation_id = "onboardingUsingPOST"
       xml_content  = file("./api/jwt_auth_op_policy.xml")
     },
@@ -817,6 +813,13 @@ module "apim_internal_api_ms_v1" {
       xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
         MS_CORE_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
         }
+      )
+    },
+    {
+      operation_id = "completeOnboardingTokenConsume"
+      xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
+        MS_ONBOARDING_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
+      }
       )
     }
   ]

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -814,13 +814,6 @@ module "apim_internal_api_ms_v1" {
         MS_CORE_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
         }
       )
-    },
-    {
-      operation_id = "completeOnboardingTokenConsume"
-      xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
-        MS_CORE_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
-        }
-      )
     }
   ]
 }

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -819,7 +819,7 @@ module "apim_internal_api_ms_v1" {
       operation_id = "completeOnboardingTokenConsume"
       xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
         MS_ONBOARDING_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
-      }
+        }
       )
     }
   ]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- remove autoApprovalOnboarding  from apim_internal_api_ms_v1 module
- remove autoApprovalOnboarding api from intefrnal open-api

<!--- Describe your changes in detail -->

### Motivation and context
This api was not invoked.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [x] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
