### PR TITLE
[EC-170] Add missing policies to KeyVault to allow access to GitHub identities

### DIFF
--- a/.identity/README.md
+++ b/.identity/README.md
@@ -21,6 +21,10 @@
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault_access_policy.key_vault_access_policy_identity_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.key_vault_access_policy_identity_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.key_vault_access_policy_pnpg_identity_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.key_vault_access_policy_pnpg_identity_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_resource_group.identity_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [github_actions_environment_secret.env_cd_secrets](https://registry.terraform.io/providers/integrations/github/5.45.0/docs/resources/actions_environment_secret) | resource |
 | [github_actions_environment_secret.env_ci_secrets](https://registry.terraform.io/providers/integrations/github/5.45.0/docs/resources/actions_environment_secret) | resource |
@@ -33,6 +37,8 @@
 | [github_repository_environment_deployment_policy.cd_deployment_policy](https://registry.terraform.io/providers/integrations/github/5.45.0/docs/resources/repository_environment_deployment_policy) | resource |
 | [github_repository_environment_deployment_policy.ci_deployment_policy](https://registry.terraform.io/providers/integrations/github/5.45.0/docs/resources/repository_environment_deployment_policy) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault.key_vault_pnpg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [github_organization_teams.all](https://registry.terraform.io/providers/integrations/github/5.45.0/docs/data-sources/organization_teams) | data source |
 

--- a/.identity/data.tf
+++ b/.identity/data.tf
@@ -2,3 +2,13 @@ data "github_organization_teams" "all" {
   root_teams_only = true
   summary_only    = true
 }
+
+data "azurerm_key_vault" "key_vault" {
+  name                = "${local.project}-kv"
+  resource_group_name = "${local.project}-sec-rg"
+}
+
+data "azurerm_key_vault" "key_vault_pnpg" {
+  name                = "${local.project}-pnpg-kv"
+  resource_group_name = "${local.project}-pnpg-sec-rg"
+}

--- a/.identity/github_managed_identity_cd.tf
+++ b/.identity/github_managed_identity_cd.tf
@@ -43,3 +43,25 @@ module "identity_cd_ms" {
     azurerm_resource_group.identity_rg
   ]
 }
+
+resource "azurerm_key_vault_access_policy" "key_vault_access_policy_identity_cd" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.identity_cd_ms.identity_principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "key_vault_access_policy_pnpg_identity_cd" {
+  key_vault_id = data.azurerm_key_vault.key_vault_pnpg.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.identity_cd_ms.identity_principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}

--- a/.identity/github_managed_identity_ci.tf
+++ b/.identity/github_managed_identity_ci.tf
@@ -43,3 +43,26 @@ module "identity_ci_ms" {
     azurerm_resource_group.identity_rg
   ]
 }
+
+resource "azurerm_key_vault_access_policy" "key_vault_access_policy_identity_ci" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.identity_ci_ms.identity_principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}
+
+
+resource "azurerm_key_vault_access_policy" "key_vault_access_policy_pnpg_identity_ci" {
+  key_vault_id = data.azurerm_key_vault.key_vault_pnpg.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.identity_ci_ms.identity_principal_id
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}

--- a/src/aks-platform/README.md
+++ b/src/aks-platform/README.md
@@ -78,7 +78,6 @@ Re-enable all the resource, commented before to complete the procedure
 | [azurerm_log_analytics_workspace.log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
-| [azurerm_monitor_action_group.opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_public_ip.pip_aks_outboud](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_resource_group.rg_monitor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -229,6 +229,7 @@
 | [azurerm_public_ip.outbound_ip_aks_platform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.azdo_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.checkout_fe_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.dashboards](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.data](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.default_roleassignment_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.docker_registry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/src/domains/pnpg-app/README.md
+++ b/src/domains/pnpg-app/README.md
@@ -106,7 +106,6 @@
 | [azurerm_kubernetes_cluster.aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
-| [azurerm_monitor_action_group.opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_private_dns_zone.internal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add KeyVault access policy for `selc-x-ms-github-identity-cx`, both pnpg and selc keyvaults

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Missing policies

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
