### PR TITLE
fix: Remove userIdForAuth from getInstitutionProductUsersUsingGET

### DIFF
--- a/src/core/api/ms_external_api/v2/getInstitutionProductUsersUsingGET_op_policy.xml.tpl
+++ b/src/core/api/ms_external_api/v2/getInstitutionProductUsersUsingGET_op_policy.xml.tpl
@@ -13,7 +13,7 @@
             var uid = context.Request.Url.Query.GetValueOrDefault("userIdForAuth", "");
 
             if(uid == "") {
-              return "";
+              uid = "m2m";
             }
 
             var aud = "${API_DOMAIN}";

--- a/src/core/api/ms_external_api/v2/open-api.yml.tpl
+++ b/src/core/api/ms_external_api/v2/open-api.yml.tpl
@@ -352,7 +352,7 @@ paths:
           - name: userIdForAuth
             in: query
             description: User's unique identifier
-            required: true
+            required: false
             style: form
             schema:
               type: string


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Re userIdForAuth is not required for API getInstitutionProductUsersUsingGET because this value is not currently used.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
