### PR TITLE
[SELC-4322] feature: Added createdAt API to internal APIM

### DIFF
--- a/src/core/api/ms_internal_api/v1/open-api.yml.tpl
+++ b/src/core/api/ms_internal_api/v1/open-api.yml.tpl
@@ -583,6 +583,50 @@ paths:
       security:
         - bearerAuth:
             - global
+  '/institutions/{institutionId}/createdAt':
+      put:
+        tags:
+          - Institution
+        summary: The service updates the createdAt field for the institution-product pair
+        description: The service updates the createdAt field for the institution-product pair
+        operationId: updateCreatedAtUsingPUT
+        parameters:
+          - name: institutionId
+            in: path
+            description: institutionId
+            required: true
+            style: simple
+            schema:
+              type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatedAtRequest'
+        responses:
+          '200':
+            description: OK
+          '400':
+            description: Bad Request
+            content:
+              application/problem+json:
+                schema:
+                  $ref: '#/components/schemas/Problem'
+          '403':
+            description: Forbidden
+            content:
+              application/problem+json:
+                schema:
+                  $ref: '#/components/schemas/Problem'
+          '404':
+            description: Not Found
+            content:
+              application/problem+json:
+                schema:
+                  $ref: '#/components/schemas/Problem'
+        security:
+          - bearerAuth:
+              - global
 components:
   schemas:
     GeographicTaxonomyResource:
@@ -1623,6 +1667,18 @@ components:
           type: string
         vatNumber:
           type: string
+    CreatedAtRequest:
+          title: CreatedAtRequest
+          type: object
+          properties:
+            activatedAt:
+              type: string
+              format: date-time
+            createdAt:
+              type: string
+              format: date-time
+            productId:
+              type: string
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -822,7 +822,7 @@ module "apim_internal_api_ms_v1" {
     {
       operation_id = "updateCreatedAtUsingPUT"
       xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
-        MS_CORE_BACKEND_BASE_URL = "http://${var.reverse_proxy_ip}/ms-core/v1/"
+        MS_CORE_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
       })
     }
   ]

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -949,6 +949,12 @@ module "apim_selfcare_support_service_v1" {
         KID                        = module.jwt.jwt_kid
         JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
       })
+    },
+    {
+      operation_id = "updateCreatedAtUsingPUT"
+      xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
+        MS_CORE_BACKEND_BASE_URL = "http://${var.reverse_proxy_ip}/ms-core/v1/"
+      })
     }
   ]
 }

--- a/src/core/apim.tf
+++ b/src/core/apim.tf
@@ -818,6 +818,12 @@ module "apim_internal_api_ms_v1" {
         MS_CORE_BACKEND_BASE_URL = "http://${var.private_dns_name}/ms-core/v1/"
         }
       )
+    },
+    {
+      operation_id = "updateCreatedAtUsingPUT"
+      xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
+        MS_CORE_BACKEND_BASE_URL = "http://${var.reverse_proxy_ip}/ms-core/v1/"
+      })
     }
   ]
 }
@@ -948,12 +954,6 @@ module "apim_selfcare_support_service_v1" {
         API_DOMAIN                 = local.api_domain
         KID                        = module.jwt.jwt_kid
         JWT_CERTIFICATE_THUMBPRINT = azurerm_api_management_certificate.jwt_certificate.thumbprint
-      })
-    },
-    {
-      operation_id = "updateCreatedAtUsingPUT"
-      xml_content = templatefile("./api/ms_internal_api/v1/core_op_policy.xml.tpl", {
-        MS_CORE_BACKEND_BASE_URL = "http://${var.reverse_proxy_ip}/ms-core/v1/"
       })
     }
   ]


### PR DESCRIPTION
### List of changes

Added createdAt API to internal APIM

### Motivation and context

This API will be invoked by a tool to update the activatedAt field in Token collection

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
