### PR TITLE
Disable redirect hub spind login to Container App env 

### DIFF
--- a/src/core/04_appgateway.tf
+++ b/src/core/04_appgateway.tf
@@ -183,11 +183,11 @@ module "app_gw" {
           backend               = "apim"
           rewrite_rule_set_name = null
         }
-        hub_spid_selc = {
-          paths                 = ["${var.spid_path_prefix}/*"]
-          backend               = "hub-spid-selc"
-          rewrite_rule_set_name = "rewrite-rule-set-hub-spid"
-        }
+        #hub_spid_selc = {
+        #  paths                 = ["${var.spid_path_prefix}/*"]
+        #  backend               = "hub-spid-selc"
+        #  rewrite_rule_set_name = "rewrite-rule-set-hub-spid"
+        #}
       }
     }
     api-pnpg = {
@@ -199,11 +199,11 @@ module "app_gw" {
           backend               = "apim"
           rewrite_rule_set_name = null
         }
-        hub_spid_pnpg = {
-          paths                 = ["${var.spid_path_prefix}/*"]
-          backend               = "hub-spid-pnpg"
-          rewrite_rule_set_name = "rewrite-rule-set-hub-spid"
-        }
+        #hub_spid_pnpg = {
+        #  paths                 = ["${var.spid_path_prefix}/*"]
+        #  backend               = "hub-spid-pnpg"
+        #  rewrite_rule_set_name = "rewrite-rule-set-hub-spid"
+        #}
       }
     }
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

hub spind login on Container App env does not working so temporally we maintain redirect to AKS

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
