### PR TITLE
Added alert when a resource fails health check returning 503 error

### DIFF
--- a/src/domains/pnpg-app/99_variables.tf
+++ b/src/domains/pnpg-app/99_variables.tf
@@ -52,7 +52,6 @@ locals {
 
 
   # Monitor
-  alert_pnpg_error_5xx_name             = "pnpg-error-5xx"
   alert_functions_exceptions_name       = "pnpg-functions-exception"
   alert_functions_exceptions_role_names = ["selc-${var.env_short}-pnpg-onboarding-fn"]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

* Rename pnpg_error_5xx with http_error_5xx
* Added unhealthy_error_503 when receive 503 error

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Sporadic 503 errors can be disregarded, as they result in false positives for 500-type errors

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
