### PR TITLE
[EC-233] - Add certificate get and list permissions for kv certificates in cicd identity

### DIFF
--- a/.identity/github_managed_identity_cd.tf
+++ b/.identity/github_managed_identity_cd.tf
@@ -53,6 +53,11 @@ resource "azurerm_key_vault_access_policy" "key_vault_access_policy_identity_cd"
     "Get",
     "List",
   ]
+
+  certificate_permissions = [
+    "Get",
+    "List",
+  ]
 }
 
 resource "azurerm_key_vault_access_policy" "key_vault_access_policy_pnpg_identity_cd" {

--- a/.identity/github_managed_identity_ci.tf
+++ b/.identity/github_managed_identity_ci.tf
@@ -53,6 +53,11 @@ resource "azurerm_key_vault_access_policy" "key_vault_access_policy_identity_ci"
     "Get",
     "List",
   ]
+
+  certificate_permissions = [
+    "Get",
+    "List",
+  ]
 }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Added get and list of selfcare's keyvault certificates to CI/CD managed identities

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The APIM v2 migration being executed in the selfcare-external-api-backend repository requires the CI pipeline to share the terraform plan results with the team.
Currently, the [CI doesn't work correctly](https://github.com/pagopa/selfcare-external-api-backend/actions/runs/9613545166/job/26516507938) due to missing permissions like the aforementioned ones.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
