### PR TITLE
[SELC-5157] Move aks_outbound to onboarding-fn

### DIFF
--- a/src/core/02_nat.tf
+++ b/src/core/02_nat.tf
@@ -42,5 +42,5 @@ resource "azurerm_nat_gateway" "nat_gateway" {
 
 resource "azurerm_nat_gateway_public_ip_association" "pip_nat_gateway" {
   nat_gateway_id       = azurerm_nat_gateway.nat_gateway.id
-  public_ip_address_id = azurerm_public_ip.aks_outbound[0].id
+  public_ip_address_id = azurerm_public_ip.aks_outbound_temp[0].id
 }

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -442,6 +442,7 @@
 | <a name="output_aks_cluster_name"></a> [aks\_cluster\_name](#output\_aks\_cluster\_name) | # AKS |
 | <a name="output_aks_fqdn"></a> [aks\_fqdn](#output\_aks\_fqdn) | n/a |
 | <a name="output_aks_outbound_ips"></a> [aks\_outbound\_ips](#output\_aks\_outbound\_ips) | n/a |
+| <a name="output_aks_outbound_temp_ips"></a> [aks\_outbound\_temp\_ips](#output\_aks\_outbound\_temp\_ips) | n/a |
 | <a name="output_aks_private_fqdn"></a> [aks\_private\_fqdn](#output\_aks\_private\_fqdn) | n/a |
 | <a name="output_api_fqdn"></a> [api\_fqdn](#output\_api\_fqdn) | n/a |
 | <a name="output_app_gateway_fqdn"></a> [app\_gateway\_fqdn](#output\_app\_gateway\_fqdn) | n/a |

--- a/src/core/aks.tf
+++ b/src/core/aks.tf
@@ -9,7 +9,7 @@ module "aks" {
 
   depends_on = [
     module.k8s_snet,
-    azurerm_public_ip.aks_outbound,
+    azurerm_public_ip.aks_outbound_temp,
   ]
 
   name                       = "${local.project}-aks"
@@ -78,7 +78,7 @@ module "aks" {
   ]
 
   alerts_enabled                                = var.aks_alerts_enabled
-  outbound_ip_address_ids                       = azurerm_public_ip.aks_outbound.*.id
+  outbound_ip_address_ids                       = azurerm_public_ip.aks_outbound_temp.*.id
   addon_azure_policy_enabled                    = true
   microsoft_defender_log_analytics_workspace_id = var.env_short == "p" ? azurerm_log_analytics_workspace.log_analytics_workspace.id : null
   tags                                          = var.tags

--- a/src/core/outputs.tf
+++ b/src/core/outputs.tf
@@ -41,6 +41,10 @@ output "aks_outbound_ips" {
   value = azurerm_public_ip.aks_outbound.*.ip_address
 }
 
+output "aks_outbound_temp_ips" {
+  value = azurerm_public_ip.aks_outbound_temp.*.ip_address
+}
+
 ## key vault ##
 output "key_vault_uri" {
   value = module.key_vault.vault_uri


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Some API deployed on AKS are now migrated to Azure Function and they need to still use the same outbound IP from AKS.

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
