### PR TITLE
[EC-233] - Make prod appgateway point to v2 apim

### DIFF
--- a/src/core/04_appgateway.tf
+++ b/src/core/04_appgateway.tf
@@ -10,9 +10,8 @@ resource "azurerm_public_ip" "appgateway_public_ip" {
 }
 
 data "azurerm_api_management" "this" {
-  # The condition is a temporary solution during apim migration to v2
-  name                = contains(["d", "u"], var.env_short) ? format("%s-apim-v2", local.project) : format("%s-apim", local.project)
-  resource_group_name = contains(["d", "u"], var.env_short) ? format("%s-api-v2-rg", local.project) : format("%s-api-rg", local.project)
+  name                = format("%s-apim-v2", local.project)
+  resource_group_name = format("%s-api-v2-rg", local.project)
 }
 
 # Subnet to host the application gateway


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
