### PR TITLE
Migrate Container App Environment DEV to New Workload Profile Environment

### DIFF
--- a/src/container-apps/_modules/container_app_environments/README.md
+++ b/src/container-apps/_modules/container_app_environments/README.md
@@ -25,11 +25,12 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_location"></a> [location](#input\_location) | Azure region | `string` | n/a | yes |
 | <a name="input_pnpg_cae_name"></a> [pnpg\_cae\_name](#input\_pnpg\_cae\_name) | Name of Container App env | `string` | n/a | yes |
+| <a name="input_pnpg_resource_group_name"></a> [pnpg\_resource\_group\_name](#input\_pnpg\_resource\_group\_name) | Name of the PNPG resource group where resources will be created | `string` | n/a | yes |
 | <a name="input_pnpg_subnet_id"></a> [pnpg\_subnet\_id](#input\_pnpg\_subnet\_id) | Id of the subnet to use for PNPG Container App Environment | `string` | n/a | yes |
 | <a name="input_pnpg_workload_profiles"></a> [pnpg\_workload\_profiles](#input\_pnpg\_workload\_profiles) | PNPG workload profiles | <pre>list(object({<br>    name                  = string<br>    workload_profile_type = string<br>    minimum_count         = number<br>    maximum_count         = number<br>  }))</pre> | <pre>[<br>  {<br>    "maximum_count": 1,<br>    "minimum_count": 0,<br>    "name": "Consumption",<br>    "workload_profile_type": "Consumption"<br>  }<br>]</pre> | no |
 | <a name="input_project"></a> [project](#input\_project) | SelfCare prefix and short environment | `string` | n/a | yes |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group where resources will be created | `string` | n/a | yes |
 | <a name="input_selc_cae_name"></a> [selc\_cae\_name](#input\_selc\_cae\_name) | Name of selc Container App env | `string` | n/a | yes |
+| <a name="input_selc_resource_group_name"></a> [selc\_resource\_group\_name](#input\_selc\_resource\_group\_name) | Name of the Selfcare resource group where resources will be created | `string` | n/a | yes |
 | <a name="input_selc_subnet_id"></a> [selc\_subnet\_id](#input\_selc\_subnet\_id) | Id of the subnet to use for SelfCare Container App Environment | `string` | n/a | yes |
 | <a name="input_selc_workload_profiles"></a> [selc\_workload\_profiles](#input\_selc\_workload\_profiles) | SELC workload profiles | <pre>list(object({<br>    name                  = string<br>    workload_profile_type = string<br>    minimum_count         = number<br>    maximum_count         = number<br>  }))</pre> | <pre>[<br>  {<br>    "maximum_count": 1,<br>    "minimum_count": 0,<br>    "name": "Consumption",<br>    "workload_profile_type": "Consumption"<br>  }<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resource tags | `map(any)` | n/a | yes |

--- a/src/container-apps/_modules/container_app_environments/container_app_environment_pnpg.tf
+++ b/src/container-apps/_modules/container_app_environments/container_app_environment_pnpg.tf
@@ -1,7 +1,7 @@
 resource "azurerm_container_app_environment" "cae_pnpg" {
   name                = var.pnpg_cae_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.pnpg_resource_group_name
 
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log_analytics_workspace.id
 

--- a/src/container-apps/_modules/container_app_environments/container_app_environment_selfcare.tf
+++ b/src/container-apps/_modules/container_app_environments/container_app_environment_selfcare.tf
@@ -1,7 +1,7 @@
 resource "azurerm_container_app_environment" "cae_selc" {
   name                = var.selc_cae_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.selc_resource_group_name
 
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log_analytics_workspace.id
 

--- a/src/container-apps/_modules/container_app_environments/variables.tf
+++ b/src/container-apps/_modules/container_app_environments/variables.tf
@@ -13,9 +13,14 @@ variable "tags" {
   description = "Resource tags"
 }
 
-variable "resource_group_name" {
+variable "selc_resource_group_name" {
   type        = string
-  description = "Name of the resource group where resources will be created"
+  description = "Name of the Selfcare resource group where resources will be created"
+}
+
+variable "pnpg_resource_group_name" {
+  type        = string
+  description = "Name of the PNPG resource group where resources will be created"
 }
 
 variable "selc_subnet_id" {

--- a/src/container-apps/_modules/networking/README.md
+++ b/src/container-apps/_modules/networking/README.md
@@ -13,6 +13,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_nat_gateway_public_ip_association.selc_subnet_pip_nat_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
 | [azurerm_network_security_group.selc_pnpg_subnet_nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
 | [azurerm_network_security_rule.selc_pnpg_cae_subnet_inbound_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
 | [azurerm_network_security_rule.selc_pnpg_cae_subnet_outbound_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
@@ -22,6 +23,7 @@ No modules.
 | [azurerm_subnet_nat_gateway_association.selc_subnet_gateway_association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
 | [azurerm_subnet_network_security_group_association.selc_pnpg_nsg_cae_subnet_association](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_nat_gateway.nat_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/nat_gateway) | data source |
+| [azurerm_public_ip.pip_outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_virtual_network.vnet_selc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs

--- a/src/container-apps/_modules/networking/data.tf
+++ b/src/container-apps/_modules/networking/data.tf
@@ -7,3 +7,8 @@ data "azurerm_nat_gateway" "nat_gateway" {
   name                = "${var.project}-nat_gw"
   resource_group_name = local.resource_group_name_natgw
 }
+
+data "azurerm_public_ip" "pip_outbound" {
+  name                = "${var.project}-aksoutbound-pip-01"
+  resource_group_name = local.resource_group_name_vnet
+}

--- a/src/container-apps/_modules/networking/subnet_selfcare.tf
+++ b/src/container-apps/_modules/networking/subnet_selfcare.tf
@@ -22,3 +22,8 @@ resource "azurerm_subnet_nat_gateway_association" "selc_subnet_gateway_associati
   nat_gateway_id = data.azurerm_nat_gateway.nat_gateway.id
   subnet_id      = azurerm_subnet.selc_container_app_snet.id
 }
+
+resource "azurerm_nat_gateway_public_ip_association" "selc_subnet_pip_nat_gateway" {
+  nat_gateway_id       = data.azurerm_nat_gateway.nat_gateway.id
+  public_ip_address_id = data.azurerm_public_ip.pip_outbound.id
+}

--- a/src/container-apps/dev/westeurope/README.md
+++ b/src/container-apps/dev/westeurope/README.md
@@ -18,6 +18,7 @@
 
 | Name | Type |
 |------|------|
+| [azurerm_resource_group.selc_cae_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.selc_container_app_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 
 ## Inputs

--- a/src/container-apps/dev/westeurope/main.tf
+++ b/src/container-apps/dev/westeurope/main.tf
@@ -26,6 +26,13 @@ resource "azurerm_resource_group" "selc_container_app_rg" {
   tags = local.tags
 }
 
+resource "azurerm_resource_group" "selc_cae_rg" {
+  name     = "${local.project}-container-app-002-rg"
+  location = local.location
+
+  tags = local.tags
+}
+
 module "networking" {
   source = "../../_modules/networking"
 
@@ -33,14 +40,13 @@ module "networking" {
 
   # inferred from vnet-common with cidr 10.1.0.0/16
   # https://github.com/pagopa/selfcare-infra/blob/9de7d03852904c1e743684a9edd40ae9df0645a8/src/core/01_network_0.tf#L9-L10
-  cidr_subnet_selc_cae = "10.1.154.0/23"
+  cidr_subnet_selc_cae = "10.1.148.0/23"
   cidr_subnet_pnpg_cae = "10.1.156.0/23"
 
-  selc_container_app_name_snet = "${local.project}-cae-cp-snet"
+  selc_container_app_name_snet = "${local.project}-cae-002-snet"
   pnpg_container_app_name_snet = "${local.project}-pnpg-cae-cp-snet"
 
   pnpg_delegation = []
-  selc_delegation = []
 
   tags = local.tags
 }
@@ -50,16 +56,16 @@ module "container_app_environments" {
 
   project             = local.project
   location            = local.location
-  resource_group_name = azurerm_resource_group.selc_container_app_rg.name
+  selc_resource_group_name = azurerm_resource_group.selc_cae_rg.name
+  pnpg_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
 
   selc_subnet_id = module.networking.subnet_selfcare.id
   pnpg_subnet_id = module.networking.subnet_pnpg.id
 
-  selc_cae_name = "${local.project}-cae-cp"
+  selc_cae_name = "${local.project}-cae-002"
   pnpg_cae_name = "${local.project}-pnpg-cae-cp"
 
   pnpg_workload_profiles = []
-  selc_workload_profiles = []
 
   zone_redundant = false
 

--- a/src/container-apps/dev/westeurope/main.tf
+++ b/src/container-apps/dev/westeurope/main.tf
@@ -54,8 +54,8 @@ module "networking" {
 module "container_app_environments" {
   source = "../../_modules/container_app_environments"
 
-  project             = local.project
-  location            = local.location
+  project                  = local.project
+  location                 = local.location
   selc_resource_group_name = azurerm_resource_group.selc_cae_rg.name
   pnpg_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
 

--- a/src/container-apps/prod/westeurope/main.tf
+++ b/src/container-apps/prod/westeurope/main.tf
@@ -50,7 +50,8 @@ module "container_app_environments" {
 
   project             = local.project
   location            = local.location
-  resource_group_name = azurerm_resource_group.selc_container_app_rg.name
+  selc_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
+  pnpg_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
 
   selc_subnet_id = module.networking.subnet_selfcare.id
   pnpg_subnet_id = module.networking.subnet_pnpg.id

--- a/src/container-apps/prod/westeurope/main.tf
+++ b/src/container-apps/prod/westeurope/main.tf
@@ -48,8 +48,8 @@ module "networking" {
 module "container_app_environments" {
   source = "../../_modules/container_app_environments"
 
-  project             = local.project
-  location            = local.location
+  project                  = local.project
+  location                 = local.location
   selc_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
   pnpg_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
 

--- a/src/container-apps/uat/westeurope/main.tf
+++ b/src/container-apps/uat/westeurope/main.tf
@@ -50,7 +50,8 @@ module "container_app_environments" {
 
   project             = local.project
   location            = local.location
-  resource_group_name = azurerm_resource_group.selc_container_app_rg.name
+  selc_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
+  pnpg_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
 
   selc_subnet_id = module.networking.subnet_selfcare.id
   pnpg_subnet_id = module.networking.subnet_pnpg.id

--- a/src/container-apps/uat/westeurope/main.tf
+++ b/src/container-apps/uat/westeurope/main.tf
@@ -48,8 +48,8 @@ module "networking" {
 module "container_app_environments" {
   source = "../../_modules/container_app_environments"
 
-  project             = local.project
-  location            = local.location
+  project                  = local.project
+  location                 = local.location
   selc_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
   pnpg_resource_group_name = azurerm_resource_group.selc_container_app_rg.name
 

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -86,7 +86,7 @@ aks_system_node_pool_node_count_max = 1
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
 reverse_proxy_ip                = "10.1.1.250"
 private_dns_name                = "selc.internal.dev.selfcare.pagopa.it"
-ca_suffix_dns_private_name      = "politewater-9af33050.westeurope.azurecontainerapps.io"
+ca_suffix_dns_private_name      = "whitemoss-eb7ef327.westeurope.azurecontainerapps.io"
 ca_pnpg_suffix_dns_private_name = "victoriousfield-e39534b8.westeurope.azurecontainerapps.io"
 spid_selc_path_prefix           = "/spid-login/v1"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* Added a workload profile.
* Renamed the environment by adding a suffix 002
* Added association IP with NAT Gateway

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is required to migrate the container app environment to a new environment with a workload profile. This migration ensures that HTTP calls exit with a predefined IP address.
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
