### PR TITLE
Workaround for oldest azurerm version required by terraform-module

### DIFF
--- a/src/core/99_main.tf
+++ b/src/core/99_main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 3.97.1"
+      version = "<= 3.116.0"
     }
 
     azuread = {
@@ -25,6 +25,7 @@ terraform {
 }
 
 provider "azurerm" {
+  skip_provider_registration = true
   features {
     key_vault {
       purge_soft_delete_on_destroy = false
@@ -36,12 +37,12 @@ data "azurerm_subscription" "current" {}
 
 data "azurerm_client_config" "current" {}
 
-provider "kubernetes" {
-  config_path = "${var.k8s_kube_config_path_prefix}/config-${local.aks_cluster_name}"
-}
+# provider "kubernetes" {
+#   config_path = "${var.k8s_kube_config_path_prefix}/config-${local.aks_cluster_name}"
+# }
 
-provider "helm" {
-  kubernetes {
-    config_path = "${var.k8s_kube_config_path_prefix}/config-${local.aks_cluster_name}"
-  }
-}
+# provider "helm" {
+#   kubernetes {
+#     config_path = "${var.k8s_kube_config_path_prefix}/config-${local.aks_cluster_name}"
+#   }
+# }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
adding

provider "azurerm" {
  features {}
  skip_provider_registration = true
} 

<!--- Describe your changes in detail -->

### Motivation and context
https://pagopa.atlassian.net/wiki/spaces/DEVOPS/pages/463241875/Terraform+Troubleshooting+FAQs#%5CuD83E%5CuDD14-Problem%3A-Error-ensuring-Resource-Providers-are-registered

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
