### PR TITLE
[PNPG-260] feat: removed institutionId_1_productId_1_name_1 index from userGroups

### DIFF
--- a/src/core/mongodb.tf
+++ b/src/core/mongodb.tf
@@ -115,10 +115,6 @@ module "mongdb_collection_user-groups" {
       unique = true
     },
     {
-      keys   = ["institutionId", "productId", "name"]
-      unique = true
-    },
-    {
       keys   = ["institutionId"]
       unique = false
     },

--- a/src/domains/pnpg-common/02_mongodb.tf
+++ b/src/domains/pnpg-common/02_mongodb.tf
@@ -91,10 +91,6 @@ module "mongdb_collection_user-groups" {
     unique = true
     },
     {
-      keys   = ["institutionId", "productId", "name"]
-      unique = true
-    },
-    {
       keys   = ["institutionId"]
       unique = false
     },


### PR DESCRIPTION
### List of changes

removed institutionId_1_productId_1_name_1 index from userGroups

### Motivation and context

This index prevented the creation of groups with same institution, product and name. Now this constraint will be evaluated via api, because we need more flexibility to allow creation of groups with same name if they are in different statuses (ACTIVE and DELETED)

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
