### PR TITLE
[SELC-6074] Feat: enable onboarding for GPU in prod pagopa dev/uat

### DIFF
--- a/src/core/env/dev/assets/product_institution_types.json
+++ b/src/core/env/dev/assets/product_institution_types.json
@@ -25,7 +25,8 @@
         "GSP": {},
         "PSP": {},
         "PT": {},
-        "PRV": {}
+        "PRV": {},
+        "GPU": {}
     },
     "prod-io-sign": {
         "PA": {},

--- a/src/core/env/uat/assets/product_institution_types.json
+++ b/src/core/env/uat/assets/product_institution_types.json
@@ -23,7 +23,8 @@
         "PA": {},
         "GSP": {},
         "PSP": {},
-        "PRV": {}
+        "PRV": {},
+        "GPU": {}
     },
     "prod-io-sign": {
         "PA": {},


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add GPU to the list of allowed instituion types for prod pagopa on dev and uat
<!--- Describe your changes in detail -->

### Motivation and context
To allow onboarding as a GPU from dashboard "avaible products" section for the product pagopa
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x ] DEV
- [x ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
