### PR TITLE
[SELC-6391] feat: open onboarding to prod-pn uat/prod

### DIFF
--- a/src/core/env/prod/assets/product_institution_types.json
+++ b/src/core/env/prod/assets/product_institution_types.json
@@ -9,7 +9,7 @@
     },
     "prod-pn": {
         "PA": {
-            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14,L8,C14"
+            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14"
         }
     },
     "prod-idpay": {

--- a/src/core/env/prod/assets/product_institution_types.json
+++ b/src/core/env/prod/assets/product_institution_types.json
@@ -9,7 +9,7 @@
     },
     "prod-pn": {
         "PA": {
-            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22"
+            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14"
         }
     },
     "prod-idpay": {

--- a/src/core/env/prod/assets/product_institution_types.json
+++ b/src/core/env/prod/assets/product_institution_types.json
@@ -9,7 +9,7 @@
     },
     "prod-pn": {
         "PA": {
-            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14"
+            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14,L8,C14"
         }
     },
     "prod-idpay": {

--- a/src/core/env/uat/assets/product_institution_types.json
+++ b/src/core/env/uat/assets/product_institution_types.json
@@ -9,7 +9,7 @@
     },
     "prod-pn": {
         "PA": {
-            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14,L8,C14"
+            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14"
         }
     },
     "prod-idpay": {

--- a/src/core/env/uat/assets/product_institution_types.json
+++ b/src/core/env/uat/assets/product_institution_types.json
@@ -9,7 +9,7 @@
     },
     "prod-pn": {
         "PA": {
-            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22"
+            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14"
         }
     },
     "prod-idpay": {

--- a/src/core/env/uat/assets/product_institution_types.json
+++ b/src/core/env/uat/assets/product_institution_types.json
@@ -9,7 +9,7 @@
     },
     "prod-pn": {
         "PA": {
-            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14"
+            "categories": "L6,L4,L45,L35,L5,L17,L15,L7,L22,L8,C14,L8,C14"
         }
     },
     "prod-idpay": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
[SELC-6391 open onboarding to prod-pn for L8,C14 categories](https://github.com/pagopa/selfcare-infra/pull/839/commits/cfc3ea294cfc53766203fe882265f799a60990de)
<!--- Describe your changes in detail -->

### Motivation and context
opening prod-pn oboarding flow for  categories L8 and C14
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
