### PR TITLE
[SELC-7498] Add new permissions for federated GitHub Actions to access secrets

### DIFF
--- a/.identity/github_managed_identity_cd.tf
+++ b/.identity/github_managed_identity_cd.tf
@@ -33,7 +33,7 @@ module "identity_cd_ms" {
   github_federations = var.cd_github_federations_ms
 
   cd_rbac_roles = {
-    subscription_roles = var.environment_cd_roles_ms.subscription
+    subscription_roles = concat(var.environment_cd_roles_ms.subscription, [azurerm_role_definition.container_apps_jobs_writer.name])
     resource_groups    = var.environment_cd_roles_ms.resource_groups
   }
 
@@ -120,5 +120,21 @@ resource "azurerm_key_vault_access_policy" "key_vault_access_policy_pnpg_identit
   secret_permissions = [
     "Get",
     "List",
+  ]
+}
+
+resource "azurerm_role_definition" "container_apps_jobs_writer" {
+  name        = "SelfCare ${var.env} ContainerApp Jobs Writer"
+  scope       = data.azurerm_subscription.current.id
+  description = "Custom role used to write container apps jobs execution properties"
+
+  permissions {
+    actions = [
+      "Microsoft.Authorization/roleDefinitions/write"
+    ]
+  }
+
+  assignable_scopes = [
+    data.azurerm_subscription.current.id
   ]
 }

--- a/.identity/github_managed_identity_ci.tf
+++ b/.identity/github_managed_identity_ci.tf
@@ -140,7 +140,9 @@ resource "azurerm_role_definition" "container_apps_jobs_reader" {
       "microsoft.app/jobs/listsecrets/action",
       "microsoft.app/jobs/detectors/read",
       "microsoft.app/jobs/execution/read",
-      "microsoft.app/jobs/executions/read"
+      "microsoft.app/jobs/executions/read",
+      "microsoft.app/containerApps/read",
+      "microsoft.app/containerApps/listSecrets/action"
     ]
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This pull request grants additional permissions to our federated GitHub Actions workflows.

Specifically, it updates the permissions to allow the actions to access secrets required for their successful execution. This change is necessary to enable new functionalities that rely on secure credentials.

### List of changes

- Updated permission scopes for the federated identity configuration.
- Ensured that workflows can now securely retrieve necessary secrets.

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
