### PR TITLE
[SELC-7722] Feat: Add new category in config.json file for new institutionType SCEC

### DIFF
--- a/src/core/env/dev/assets/config.json
+++ b/src/core/env/dev/assets/config.json
@@ -7,8 +7,7 @@
     },
     "prod-interop": {
       "ipa": {
-        "GSP": "L37,SAG,S01G",
-        "PA": "C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA"
+        "SCEC": "S01G"
       }
     },
     "prod-io-premium": {

--- a/src/core/env/uat/assets/config.json
+++ b/src/core/env/uat/assets/config.json
@@ -7,8 +7,7 @@
     },
     "prod-interop": {
       "ipa": {
-        "GSP": "L37,SAG,S01G",
-        "PA": "C17,C16,L10,L19,L13,L2,C10,L20,L21,L22,L15,L1,C13,C5,L40,L11,L39,L46,L8,L34,L7,L35,L45,L47,L6,L12,L24,L28,L42,L36,L44,C8,C3,C7,C14,L16,C11,L33,C12,L43,C2,L38,C1,L5,L4,L31,L18,L17,S01,SA"
+        "SCEC": "S01G"
       }
     },
     "prod-io-premium": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

updated prod-interop section in config.json file. Removed GSP and PA and added new category for the new institutionType SCEC

### Motivation and context

'Società in conto economico consolidato' that are classified in IPA with the 'GSP' category can join by selecting the 'SCEC' category

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
